### PR TITLE
Revise makefile to allow specification of an alternative path to rgbds

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,16 +11,17 @@ Python 2.7 is required.
 ```bash
 sudo apt-get install make gcc bison git python
 
-git clone https://github.com/bentley/rgbds
-cd rgbds
+wget https://github.com/rednex/rgbds/releases/download/v0.2.5/rgbds-0.2.5.tar.gz
+tar -xvf rgbds-0.2.5.tar.gz
+cd rgbds-0.2.5
 sudo make install
 cd ..
 
-git clone --recursive https://github.com/pret/pokecrystal
-cd pokecrystal
+git clone --recursive https://github.com/dabomstew/pokecrystal-speedchoice
+cd pokecrystal-speedchoice
 ```
 
-To build **pokecrystal.gbc**:
+To build **crystal-speedchoice.gbc**:
 
 ```bash
 make
@@ -34,16 +35,17 @@ In **Terminal**, run:
 ```bash
 xcode-select --install
 
-git clone https://github.com/bentley/rgbds
-cd rgbds
+wget https://github.com/rednex/rgbds/releases/download/v0.2.5/rgbds-0.2.5.tar.gz
+tar -xvf rgbds-0.2.5.tar.gz
+cd rgbds-0.2.5
 sudo make install
 cd ..
 
-git clone --recursive https://github.com/pret/pokecrystal
-cd pokecrystal
+git clone --recursive https://github.com/dabomstew/pokecrystal-speedchoice
+cd pokecrystal-speedchoice
 ```
 
-To build **pokecrystal.gbc**:
+To build **crystal-speedchoice.gbc**:
 
 ```bash
 make
@@ -56,18 +58,18 @@ To build on Windows, install [**Cygwin**](http://cygwin.com/install.html) with t
 
 In the installer, select the following packages: `make` `git` `python` `gettext`
 
-Then get the most recent version of [**rgbds**](https://github.com/bentley/rgbds/releases/).
+Then get version 0.2.5 of [**rgbds**](https://github.com/bentley/rgbds/releases/).
 Extract the archive and put `rgbasm.exe`, `rgblink.exe` and `rgbfix.exe` in `C:\cygwin64\usr\local\bin`.
 
 In the **Cygwin terminal**:
 
 ```bash
 
-git clone --recursive https://github.com/pret/pokecrystal
-cd pokecrystal
+git clone --recursive https://github.com/dabomstew/pokecrystal-speedchoice
+cd pokecrystal-speedchoice
 ```
 
-To build **pokecrystal.gbc**:
+To build **crystal-speedchoice.gbc**:
 
 ```bash
 make
@@ -76,3 +78,17 @@ make
 ## notes
 
 - If `gettext` no longer exists, grab `libsasl2-3` `ca-certificates`.
+
+# Notes for all OSes
+
+RGBDS after v0.2.5 will not build this project, and v0.2.5 will not build projects that require RGBDS versions after v0.2.5.  If you want to have both versions installed, you can install v0.2.5 in a custom directory as such:
+
+```bash
+sudo make install PREFIX=/path/you/want
+```
+
+To use this version of RGBDS to build **crystal-speedchoice.gbc**:
+
+```bash
+make RGBDS=/path/you/want/bin
+```

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 PYTHON := python
-MD5 := md5sum -c --quiet
+RGBDS := $(shell dirname $(shell which rgbasm))
+ASM := $(RGBDS)/rgbasm
+LD := $(RGBDS)/rgblink
+FIX := $(RGBDS)/rgbfix
 
 .SUFFIXES:
-.PHONY: all clean crystal crystal11
+.PHONY: all clean crystal
 .SECONDEXPANSION:
 .PRECIOUS: %.2bpp %.1bpp
 
@@ -34,20 +37,17 @@ all: $(roms)
 crystal: crystal-speedchoice.gbc
 
 clean:
-	rm -f $(roms) $(crystal_obj) $(crystal11_obj) $(roms:.gbc=.map) $(roms:.gbc=.sym)
-
-compare: crystal-speedchoice.gbc
-	@$(MD5) roms.md5
+	rm -f $(roms) $(crystal_obj) $(roms:.gbc=.map) $(roms:.gbc=.sym)
 
 %.asm: ;
 
 %.o: dep = $(shell $(includes) $(@D)/$*.asm)
 %.o: %.asm $$(dep)
-	rgbasm -o $@ $<
+	$(ASM) -o $@ $<
 
 crystal-speedchoice.gbc: $(crystal_obj)
-	rgblink -n crystal-speedchoice.sym -m crystal-speedchoice.map -o $@ $^
-	rgbfix -Cjv -i KAPB -k 01 -l 0x33 -m 0x10 -p 0 -n 3 -r 3 -t PM_CRYSTAL $@
+	$(LD) -n crystal-speedchoice.sym -m crystal-speedchoice.map -o $@ $^
+	$(FIX) -Cjv -i KAPB -k 01 -l 0x33 -m 0x10 -p 0 -n 3 -r 3 -t PM_CRYSTAL $@
 
 %.png: ;
 %.2bpp: %.png ; $(gfx) 2bpp $<


### PR DESCRIPTION
This will allow users to have RGBDS v0.2.5 (required to build this project) installed alongside RGBDS v0.3.3 (required to build other projects).