### PR TITLE
Allow player to fly in Kanto upon first visit to Kanto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 PYTHON := python
+PYTHON3 := python3
 RGBDS := $(shell dirname $(shell which rgbasm))
 ASM := $(RGBDS)/rgbasm
 LD := $(RGBDS)/rgblink
 FIX := $(RGBDS)/rgbfix
 
 .SUFFIXES:
-.PHONY: all clean crystal
+.PHONY: all clean crystal config
 .SECONDEXPANSION:
 .PRECIOUS: %.2bpp %.1bpp
 
@@ -36,6 +37,8 @@ roms := crystal-speedchoice.gbc
 all: $(roms)
 crystal: crystal-speedchoice.gbc
 
+config: crystal-speedchoice.ini
+
 clean:
 	rm -f $(roms) $(crystal_obj) $(roms:.gbc=.map) $(roms:.gbc=.sym)
 
@@ -59,3 +62,6 @@ gfx/pics/%/normal.pal gfx/pics/%/bitmask.asm gfx/pics/%/frames.asm: gfx/pics/%/f
 %.bin: ;
 %.blk: ;
 %.tilemap: ;
+
+%.ini: %.gbc %.sym
+	$(PYTHON3) genrandoini.py $^ $@

--- a/battle/core.asm
+++ b/battle/core.asm
@@ -2501,6 +2501,15 @@ WinTrainerBattle: ; 3cfa4
 	call PrintWinLossText
 
 .skip_win_loss_text
+	ld a, [OtherTrainerClass]
+	cp POKEMANIAC
+	jr nz, .not_pokemaniac
+	ld a, BANK(sStatsNumPokemaniacsFought)
+	call GetSRAMBank
+	ld hl, sStatsNumPokemaniacsFought
+	inc [hl]
+	call CloseSRAM
+.not_pokemaniac
 	jp HandleBattleReward
 
 .mobile

--- a/engine/intro_permaoptions.asm
+++ b/engine/intro_permaoptions.asm
@@ -16,15 +16,10 @@ IntroPermaOptions::
 	ld [RandomizedMovesStatus], a
 	ld a, "@"
 	ld [PlayerName], a
+	ld hl, PlayerGender
+	set 0, [hl]
 .setOptions
 	callba PermaOptionsMenu
-	ld de, PlayerName
-	ld a, [de]
-	cp "@"
-	jr nz, .name_okay
-	ld b, 1
-	callba NamingScreen
-.name_okay
 	call ClearTileMap
 	call PrintPermaOptionsToScreen
 	ld hl, AreOptionsAcceptable
@@ -245,7 +240,7 @@ EarlyKantoText::
 PleaseSetOptions::
 	text_jump _PleaseSetOptions
 	db "@"
-	
+
 AreOptionsAcceptable::
 	text_jump _AreOptionsAcceptable
 	db "@"

--- a/engine/options_menu.asm
+++ b/engine/options_menu.asm
@@ -7,7 +7,7 @@ NUM_PERMAOPTIONS_PAGES EQU 2
 PermaOptionsMenu:
 	ld a, FIRST_PERMAOPTIONS_PAGEID
 	jr OptionsMenuCommon
-	
+
 OptionsMenu:
 	xor a
 	; fallthrough
@@ -48,6 +48,22 @@ OptionsMenuCommon:: ; e41d0
 	ld [wOptionsMenuID], a
 	jr .pageLoad
 .doExit
+	ld a, [wOptionsMenuID]
+	cp FIRST_PERMAOPTIONS_PAGEID
+	jr c, .exit
+	ld a, [PlayerName]
+	cp "@"
+	jr nz, .exit
+	ld a, [Options2]
+	push af
+	and $ff ^ (1 << HOLD_TO_MASH)
+	ld [Options2], a
+	ld hl, NameNotSetText
+	call PrintText
+	pop af
+	ld [Options2], a
+	jr .pageLoad
+.exit
 	pop af
 	ld [hInMenu], a
 	ld de, SFX_TRANSACTION
@@ -286,3 +302,16 @@ INCLUDE "engine/options/main_options.asm"
 INCLUDE "engine/options/main_options_2.asm"
 INCLUDE "engine/options/perma_options.asm"
 INCLUDE "engine/options/perma_options_2.asm"
+
+NameNotSetText::
+	text "Please set your"
+	line "name on page 2!@"
+	start_asm
+	ld de, SFX_WRONG
+	call PlaySFX
+	call WaitSFX
+	ld hl, .done
+	ret
+.done
+	text ""
+	prompt

--- a/engine/playthrough_stats_screen.asm
+++ b/engine/playthrough_stats_screen.asm
@@ -565,6 +565,7 @@ PSMiscConfig::
 	stat_screen_entry PSMiscSavesString, STATTYPE_2BYTE, sStatsSaveCount
 	stat_screen_entry PSMiscReloadsString, STATTYPE_2BYTE, sStatsReloadCount
 	stat_screen_entry PSMiscClockResetsString, STATTYPE_2BYTE, sStatsClockResetCount
+	stat_screen_entry PSMiscPokemaniacsFoughtString, STATTYPE_2BYTE, sStatsNumPokemaniacsFought
 	dw 0
 	
 PlayerStatsString:
@@ -671,6 +672,8 @@ PSMiscReloadsString:
 	db "SAVE RELOADS:@"
 PSMiscClockResetsString:
 	db "CLOCK RESETS:@"
+PSMiscPokemaniacsFoughtString:
+	db "No. #MANIACS:@"
 
 PSPageStartString:
 	db "PAGE@"

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -2373,7 +2373,7 @@ KANTO_FLYPOINT EQU const_value
 	flypoint FUCHSIA,     FUCHSIA_CITY
 	flypoint CINNABAR,    CINNABAR_ISLAND
 	flypoint INDIGO,      INDIGO_PLATEAU
-	db -1, -1
+	db -1,
 
 ; 91c8f
 
@@ -2430,18 +2430,23 @@ FlyMap: ; 91c90
 ; can be flown to even if none are enabled
 
 ; To prevent both of these things from happening when the player
-; enters Kanto, fly access is restricted until Indigo Plateau is
+; enters Kanto, fly access is restricted until at least one city is
 
 ; visited and its flypoint enabled
 	push af
-	ld hl, .KantoSpawns
+	ld hl, Flypoints + 2 * KANTO_FLYPOINT
+	ld b, KANTO_FLYPOINT - 1
 .loop_spawns
 	ld a, [hli]
 	cp $ff
 	jr z, .NoKanto
+	inc b
+	ld c, [hl]
+	inc hl
 	push hl
-	ld c, a
+	push bc
 	call HasVisitedSpawn
+	pop bc
 	pop hl
 	and a
 	jr z, .loop_spawns
@@ -2453,18 +2458,8 @@ FlyMap: ; 91c90
 ; ...and end at Indigo Plateau
 	ld a, FLY_INDIGO
 	ld [EndFlypoint], a
-; Because Indigo Plateau is the first flypoint the player
-
-; visits, it's made the default flypoint
-	dec hl
-	ld a, [hl]
-	ld hl, Flypoints + 1
-	ld de, 2
-	call IsInArray
+; Use the lowest index flypoint the player visits as the default flypoint
 	ld a, b
-	jr c, .valid_kanto_spawn
-	ld a, FLY_INDIGO ; error handling
-.valid_kanto_spawn
 	ld [wd002], a
 ; Fill out the map
 	call FillKantoMap
@@ -2474,7 +2469,7 @@ FlyMap: ; 91c90
 	ret
 
 .NoKanto
-; If Indigo Plateau hasn't been visited, we use Johto's map instead
+; If Kanto hasn't been visited, we use Johto's map instead
 
 ; Start from New Bark Town
 	ld a, FLY_NEW_BARK
@@ -2499,21 +2494,6 @@ FlyMap: ; 91c90
 	ret
 
 ; 91d11
-
-.KantoSpawns
-	db SPAWN_PALLET
-	db SPAWN_VIRIDIAN
-	db SPAWN_PEWTER
-	db SPAWN_CERULEAN
-	db SPAWN_ROCK_TUNNEL
-	db SPAWN_VERMILION
-	db SPAWN_LAVENDER
-	db SPAWN_SAFFRON
-	db SPAWN_CELADON
-	db SPAWN_FUCHSIA
-	db SPAWN_CINNABAR
-	db SPAWN_INDIGO
-	db $ff
 
 _Area: ; 91d11
 ; e: Current landmark

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -2379,7 +2379,7 @@ KANTO_FLYPOINT EQU const_value
 
 ret_91c8f: ; 91c8f
 	ret
-
+	
 ; 91c90
 
 FlyMap: ; 91c90
@@ -2458,6 +2458,10 @@ FlyMap: ; 91c90
 ; visits, it's made the default flypoint
 	dec hl
 	ld a, [hl]
+	ld hl, Flypoints + 1
+	ld de, 2
+	call IsInArray
+	ld a, b
 	ld [wd002], a
 ; Fill out the map
 	call FillKantoMap
@@ -2507,9 +2511,6 @@ FlyMap: ; 91c90
 	db SPAWN_CINNABAR
 	db SPAWN_INDIGO
 	db $ff
-
-HasVisitedAnySpawn:
-	ret
 
 _Area: ; 91d11
 ; e: Current landmark

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -2304,7 +2304,7 @@ TownMapBubble: ; 91bb5
 	call .Name
 ; Up/down arrows
 	hlcoord 18, 1
-	ld [hl], $34	
+	ld [hl], $34
 	ret
 
 .Where
@@ -2428,7 +2428,7 @@ ret_91c8f: ; 91c8f
 	ld a, d
 	ld [wd00a], a
 	ret
-	
+
 ; 91c90
 
 FlyMap: ; 91c90

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -2416,7 +2416,7 @@ KANTO_FLYPOINT EQU const_value
 	flypoint FUCHSIA,     FUCHSIA_CITY
 	flypoint CINNABAR,    CINNABAR_ISLAND
 	flypoint INDIGO,      INDIGO_PLATEAU
-	db -1,
+	db -1
 
 ; 91c8f
 

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -2434,11 +2434,18 @@ FlyMap: ; 91c90
 
 ; visited and its flypoint enabled
 	push af
-	ld c, SPAWN_INDIGO
-	call HasVisitedSpawn
-	and a
+	ld hl, .KantoSpawns
+.loop_spawns
+	ld a, [hli]
+	cp $ff
 	jr z, .NoKanto
-; Kanto's map is only loaded if we've visited Indigo Plateau
+	push hl
+	ld c, a
+	call HasVisitedSpawn
+	pop hl
+	and a
+	jr z, .loop_spawns
+; Kanto's map is only loaded if we've visited any place in Kanto
 
 ; Flypoints begin at Pallet Town...
 	ld a, FLY_PALLET
@@ -2449,6 +2456,8 @@ FlyMap: ; 91c90
 ; Because Indigo Plateau is the first flypoint the player
 
 ; visits, it's made the default flypoint
+	dec hl
+	ld a, [hl]
 	ld [wd002], a
 ; Fill out the map
 	call FillKantoMap
@@ -2483,6 +2492,24 @@ FlyMap: ; 91c90
 	ret
 
 ; 91d11
+
+.KantoSpawns
+	db SPAWN_PALLET
+	db SPAWN_VIRIDIAN
+	db SPAWN_PEWTER
+	db SPAWN_CERULEAN
+	db SPAWN_ROCK_TUNNEL
+	db SPAWN_VERMILION
+	db SPAWN_LAVENDER
+	db SPAWN_SAFFRON
+	db SPAWN_CELADON
+	db SPAWN_FUCHSIA
+	db SPAWN_CINNABAR
+	db SPAWN_INDIGO
+	db $ff
+
+HasVisitedAnySpawn:
+	ret
 
 _Area: ; 91d11
 ; e: Current landmark

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -2373,7 +2373,7 @@ KANTO_FLYPOINT EQU const_value
 	flypoint FUCHSIA,     FUCHSIA_CITY
 	flypoint CINNABAR,    CINNABAR_ISLAND
 	flypoint INDIGO,      INDIGO_PLATEAU
-	db -1
+	db -1, -1
 
 ; 91c8f
 
@@ -2462,6 +2462,9 @@ FlyMap: ; 91c90
 	ld de, 2
 	call IsInArray
 	ld a, b
+	jr c, .valid_kanto_spawn
+	ld a, FLY_INDIGO ; error handling
+.valid_kanto_spawn
 	ld [wd002], a
 ; Fill out the map
 	call FillKantoMap

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -2514,6 +2514,11 @@ GetJohtoFlyParams:
 	ret
 
 GetKantoFlyParams:
+	ld c, SPAWN_INDIGO
+	call HasVisitedSpawn
+	and a
+	ld b, FLY_INDIGO
+	jr nz, .spawnIndigo
 	ld hl, Flypoints + 2 * KANTO_FLYPOINT
 	ld b, KANTO_FLYPOINT - 1
 .loop_spawns
@@ -2531,6 +2536,7 @@ GetKantoFlyParams:
 	and a
 	jr z, .loop_spawns
 ; Kanto's map is only loaded if we've visited any place in Kanto
+.spawnIndigo
 
 ; Flypoints begin at Pallet Town...
 	ld a, FLY_PALLET

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -2183,6 +2183,9 @@ FlyMapScroll: ; 91b73
 	ld a, [hl]
 	and D_DOWN
 	jr nz, .ScrollPrev
+	ld a, [hl]
+	and D_LEFT | D_RIGHT
+	jr nz, .SwapRegion
 	ret
 
 .ScrollNext
@@ -2211,11 +2214,51 @@ FlyMapScroll: ; 91b73
 	dec [hl]
 	call CheckIfVisitedFlypoint
 	jr z, .ScrollPrev
+	jr .Finally
+
+.SwapRegion:
+	ld a, [hWY]
+	and a
+	jr nz, .johtoToKanto
+; Start from New Bark Town
+	call GetJohtoFlyParams
+; Fill out the map
+	ld d, 1
+	call .showHidePlayer
+	ld a, $90
+	jr .mapFinally
+
+.johtoToKanto
+	call GetKantoFlyParams
+	ret c
+	ld d, 0
+	call .showHidePlayer
+	xor a
+.mapFinally
+	ld [hWY], a
 .Finally
 	call TownMapBubble
 	call WaitBGMap
 	xor a
 	ld [hBGMapMode], a
+	ret
+
+.showHidePlayer:
+	ld hl, wd008
+	ld a, [hli]
+	ld b, [hl]
+	ld c, a
+	ld hl, SPRITEANIMSTRUCT_YCOORD
+	add hl, bc
+	ld a, [wd007]
+	cp d
+	jr nz, .show
+	ld a, $c0
+	jr .got_y
+.show
+	ld a, [wd00a]
+.got_y
+	ld [hl], a
 	ret
 
 ; 91bb5
@@ -2378,43 +2421,29 @@ KANTO_FLYPOINT EQU const_value
 ; 91c8f
 
 ret_91c8f: ; 91c8f
+	ld a, c
+	ld [wd008], a
+	ld a, b
+	ld [wd008+1], a
+	ld a, d
+	ld [wd00a], a
 	ret
 	
 ; 91c90
 
 FlyMap: ; 91c90
-	ld a, [MapGroup]
-	ld b, a
-	ld a, [MapNumber]
-	ld c, a
-	call GetWorldMapLocation
-; If we're not in a valid location, i.e. Pokecenter floor 2F,
-
-; the backup map information is used
-	cp SPECIAL_MAP
-	jr nz, .CheckRegion
-	ld a, [BackupMapGroup]
-	ld b, a
-	ld a, [BackupMapNumber]
-	ld c, a
-	call GetWorldMapLocation
-.CheckRegion
-; The first 46 locations are part of Johto. The rest are in Kanto
-	cp KANTO_LANDMARK
+	ld a, $90
+	ld [hWY], a
+	call FlyMapIsInKanto
 	jr nc, .KantoFlyMap
 .JohtoFlyMap
 ; Note that .NoKanto should be modified in tandem with this branch
 	push af
 ; Start from New Bark Town
-	ld a, FLY_NEW_BARK
-	ld [wd002], a
-; Flypoints begin at New Bark Town...
-	ld [StartFlypoint], a
-; ..and end at Silver Cave
-	ld a, FLY_MT_SILVER
-	ld [EndFlypoint], a
+	call GetJohtoFlyParams
+	xor a
+	ld [wd007], a
 ; Fill out the map
-	call FillJohtoMap
 	call .MapHud
 	pop af
 	call TownMapPlayerIcon
@@ -2434,6 +2463,57 @@ FlyMap: ; 91c90
 
 ; visited and its flypoint enabled
 	push af
+	call GetKantoFlyParams
+	jr c, .NoKanto
+; Fill out the map
+	xor a
+	ld [hWY], a
+	inc a
+	ld [wd007], a
+	call .MapHud
+	pop af
+	call TownMapPlayerIcon
+	ret
+
+.NoKanto
+; If Kanto hasn't been visited, we use Johto's map instead
+
+; Start from New Bark Town
+	call GetJohtoFlyParams
+	xor a
+	ld [wd007], a
+	pop af
+.MapHud
+	call FillKantoMap
+	call TownMapBubble
+	call TownMapPals
+	hlbgcoord 0, 0, VBGMap1
+	call TownMapBGUpdate
+	call FillJohtoMap
+	call TownMapBubble
+	call TownMapPals
+	hlbgcoord 0, 0
+	call TownMapBGUpdate
+	call TownMapMon
+	ld a, c
+	ld [wd003], a
+	ld a, b
+	ld [wd004], a
+	ret
+
+; 91d11
+
+GetJohtoFlyParams:
+	ld a, FLY_NEW_BARK
+	ld [wd002], a
+; Flypoints begin at New Bark Town...
+	ld [StartFlypoint], a
+; ..and end at Silver Cave
+	ld a, FLY_MT_SILVER
+	ld [EndFlypoint], a
+	ret
+
+GetKantoFlyParams:
 	ld hl, Flypoints + 2 * KANTO_FLYPOINT
 	ld b, KANTO_FLYPOINT - 1
 .loop_spawns
@@ -2461,39 +2541,33 @@ FlyMap: ; 91c90
 ; Use the lowest index flypoint the player visits as the default flypoint
 	ld a, b
 	ld [wd002], a
-; Fill out the map
-	call FillKantoMap
-	call .MapHud
-	pop af
-	call TownMapPlayerIcon
+	and a
 	ret
 
-.NoKanto
-; If Kanto hasn't been visited, we use Johto's map instead
-
-; Start from New Bark Town
-	ld a, FLY_NEW_BARK
-	ld [wd002], a
-; Flypoints begin at New Bark Town...
-	ld [StartFlypoint], a
-; ..and end at Silver Cave
-	ld a, FLY_MT_SILVER
-	ld [EndFlypoint], a
-	call FillJohtoMap
-	pop af
-.MapHud
-	call TownMapBubble
-	call TownMapPals
-	hlbgcoord 0, 0 ; BG Map 0
-	call TownMapBGUpdate
-	call TownMapMon
-	ld a, c
-	ld [wd003], a
-	ld a, b
-	ld [wd004], a
+.NoKanto:
+	scf
 	ret
 
-; 91d11
+FlyMapIsInKanto:
+	ld a, [MapGroup]
+	ld b, a
+	ld a, [MapNumber]
+	ld c, a
+	call GetWorldMapLocation
+; If we're not in a valid location, i.e. Pokecenter floor 2F,
+
+; the backup map information is used
+	cp SPECIAL_MAP
+	jr nz, .CheckRegion
+	ld a, [BackupMapGroup]
+	ld b, a
+	ld a, [BackupMapNumber]
+	ld c, a
+	call GetWorldMapLocation
+.CheckRegion
+; The first 46 locations are part of Johto. The rest are in Kanto
+	cp KANTO_LANDMARK
+	ret
 
 _Area: ; 91d11
 ; e: Current landmark

--- a/genrandoini.py
+++ b/genrandoini.py
@@ -76,9 +76,8 @@ def main():
         setconfig(key, '0x{:X}'.format(syms[sym] + extra))
     
     def set_tm_text(num, key, txt):
-        setconfig('TMText[]', '[{:d}, 0x{:X}, {}]'.format(num,
-                                                          syms[key] + 1,
-                                                          txt))
+        setconfig('TMText[]',
+                  '[{:d},0x{:X},{}]'.format(num, syms[key] + 1, txt))
 
     # Print version
     args.rom.seek(0x14c)

--- a/genrandoini.py
+++ b/genrandoini.py
@@ -76,7 +76,9 @@ def main():
         setconfig(key, '0x{:X}'.format(syms[sym] + extra))
     
     def set_tm_text(num, key, txt):
-        setconfig('TMText[]', '[{:d}, 0x{:X}, {}]'.format(num, key, txt))
+        setconfig('TMText[]', '[{:d}, 0x{:X}, {}]'.format(num,
+                                                          syms[key] + 1,
+                                                          txt))
 
     # Print version
     args.rom.seek(0x14c)
@@ -196,51 +198,51 @@ def main():
         setconfig('StaticPokemonGameCorner[]',
                   '[0x{:X}, 0x{:X}, 0x{:X}, 0x{:X}]'.format(*offs))
 
-    set_tm_text(1, syms['UnknownText_0x9d8da'],
+    set_tm_text(1, 'UnknownText_0x9d8da',
                 'That is\\n%m.\\e')
-    set_tm_text(3, syms['UnknownText_0x71db3'],
+    set_tm_text(3, 'UnknownText_0x71db3',
                 'TM03 is\\n%m.\\p'
                 'It\'s a terrifying\\n'
                 'move!\\e')
-    set_tm_text(5, syms['Text_RoarOutro'],
+    set_tm_text(5, 'Text_RoarOutro',
                 'WROOOAR!\\nIT\'S %m!\\e')
-    set_tm_text(6, syms['UnknownText_0x196002'],
+    set_tm_text(6, 'UnknownText_0x196002',
                 'JANINE: You\'re so\\n'
                 'tough! I have a \\l'
                 'special gift!\\p'
                 'It\'s %m!\\e')
-    set_tm_text(7, syms['UnknownText_0x1893f4'],
+    set_tm_text(7, 'UnknownText_0x1893f4',
                 'MANAGER: TM07 is\\n'
                 'my %m.\\p'
                 'It\'s a powerful\\n'
                 'technique!\\e')
-    set_tm_text(8, syms['UnknownText_0x19452c'],
+    set_tm_text(8, 'UnknownText_0x19452c',
                 'That happens to be\\n'
                 '%m.\\p'
                 'If any rocks are\\n'
                 'in your way, find\\l'
                 'ROCK SMASH!\\e')
-    set_tm_text(10, syms['HiddenPowerGuyText2'],
+    set_tm_text(10, 'HiddenPowerGuyText2',
                 'Do you see it? It\\n'
                 'is %m!\\e')
-    set_tm_text(11, syms['UnknownText_0x5e821'],
+    set_tm_text(11, 'UnknownText_0x5e821',
                 'It\'s %m.\\n'
                 'Use it wisely.\\e')
-    set_tm_text(12, syms['UnknownText_0x62df6'],
+    set_tm_text(12, 'UnknownText_0x62df6',
                 'It\'s %m.\\p'
                 'Use it on\\n'
                 'enemy [POKé]MON.\\e')
-    set_tm_text(13, syms['UnknownText_0x9d1c7'],
+    set_tm_text(13, 'UnknownText_0x9d1c7',
                 'That there\'s\\n'
                 '%m.\\p'
                 'It\'s a rare move.\\e')
-    set_tm_text(16, syms['UnknownText_0x199def'],
+    set_tm_text(16, 'UnknownText_0x199def',
                 'That TM contains\\n'
                 '%m.\\p'
                 'It demonstrates\\n'
                 'the harshness of\\l'
                 'winter.\\e')
-    set_tm_text(19, syms['UnknownText_0x72cb0'],
+    set_tm_text(19, 'UnknownText_0x72cb0',
                 'That was a\\n'
                 'delightful match.\\p'
                 'I felt inspired.\\n'
@@ -251,31 +253,31 @@ def main():
                 'move!\\p'
                 'Please use it if\\n'
                 'it pleases you…\\e')
-    set_tm_text(23, syms['UnknownText_0x9c3a5'],
+    set_tm_text(23, 'UnknownText_0x9c3a5',
                 '…That teaches\\n'
                 '%m.\\e')
-    set_tm_text(24, syms['ClairText_DescribeDragonbreathDragonDen'],
+    set_tm_text(24, 'ClairText_DescribeDragonbreathDragonDen',
                 'That contains\\n'
                 '%m.\\p'
                 'If you don\'t want\\n'
                 'it, you don\'t have\\l'
                 'to take it.\\e')
-    set_tm_text(24, syms['BlackthornGymClairText_DescribeTM24'],
+    set_tm_text(24, 'BlackthornGymClairText_DescribeTM24',
                 'That contains\\n'
                 '%m.\\p'
                 'If you don\'t want\\n'
                 'it, you don\'t have\\l'
                 'to take it.\\e')
-    set_tm_text(29, syms['MrPsychicText2'],
+    set_tm_text(29, 'MrPsychicText2',
                 'TM29 is\\n'
                 '%m.\\p'
                 'It may be\\n'
                 'useful.\\e')
-    set_tm_text(30, syms['UnknownText_0x9a0ec'],
+    set_tm_text(30, 'UnknownText_0x9a0ec',
                 'It\'s %m.\\p'
                 'Use it if it\\n'
                 'appeals to you.\\e')
-    set_tm_text(31, syms['UnknownText_0x68648'],
+    set_tm_text(31, 'UnknownText_0x68648',
                 'By using a TM, a\\n'
                 '[POKé]MON will\\p'
                 'instantly learn a\\n'
@@ -284,28 +286,28 @@ def main():
                 'act--a TM can be\\l'
                 'used only once.\\p'
                 'TM31 contains\\n%m.\\e')
-    set_tm_text(37, syms['SandstormHouseSandstormDescription'],
+    set_tm_text(37, 'SandstormHouseSandstormDescription',
                 'TM37 happens to be\\n'
                 '%m.\\p'
                 'It\'s for advanced\\n'
                 'trainers only.\\p'
                 'Use it if you\\n'
                 'dare. Good luck!\\e')
-    set_tm_text(42, syms['UnknownText_0x1a9d86'],
+    set_tm_text(42, 'UnknownText_0x1a9d86',
                 'TM42 contains\\n'
                 '%m…\\p'
                 '…Zzz…\\e')
-    set_tm_text(45, syms['UnknownText_0x54302'],
+    set_tm_text(45, 'UnknownText_0x54302',
                 'It\'s %m!\\p'
                 'Isn\'t it just per-\\n'
                 'fect for a cutie\\l'
                 'like me?\\e')
-    set_tm_text(49, syms['BugsyText_FuryCutterSpeech'],
+    set_tm_text(49, 'BugsyText_FuryCutterSpeech',
                 'TM49 contains\\n'
                 '%m.\\p'
                 'Isn\'t it great?\\n'
                 'I discovered it!\\e')
-    set_tm_text(50, syms['Text_Route31DescribeNightmare'],
+    set_tm_text(50, 'Text_Route31DescribeNightmare',
                 'TM50 is\\n'
                 '%m.\\p'
                 'Ooooh…\\n'

--- a/sram.asm
+++ b/sram.asm
@@ -272,6 +272,7 @@ sStatsItemsSold:: ds 2
 sStatsMovesLearnt:: ds 2
 sStatsBallsThrown:: ds 2
 sStatsPokemonCaughtInBalls:: ds 2
+sStatsNumPokemaniacsFought:: dw
 sStatsEnd::
 
 


### PR DESCRIPTION
Before: Upon arriving at Vermilion, player can only fly to Johto. Muscle memory would thus screw you over as your character lands in New Bark and your controller lands on the street below.

After: Upon arriving at Vermilion, player can only fly to Vermilion.  Thereafter flying works as it would in vanilla minus the Indigo Plateau fly point.