### PR TITLE
Always try to trigger rockets

### DIFF
--- a/maps/BlackthornGym1F.asm
+++ b/maps/BlackthornGym1F.asm
@@ -61,6 +61,8 @@ BlackthornGymClairScript:
 	playsound SFX_GET_BADGE
 	waitsfx
 	setflag ENGINE_RISINGBADGE
+	checkcode VAR_BADGES
+	scall BlackthornGymTriggerRockets
 	specialphonecall SPECIALCALL_MASTERBALL
 	writetext BlackthornGymClairText_DescribeBadge
 	jump .GiveTM
@@ -106,6 +108,17 @@ BlackthornGymClairScript:
 	waitbutton
 	closetext
 	end
+
+BlackthornGymTriggerRockets:
+	if_equal 7, .RadioTowerRockets
+	if_equal 6, .GoldenrodRockets
+	end
+
+.GoldenrodRockets
+	jumpstd goldenrodrockets
+
+.RadioTowerRockets
+	jumpstd radiotowerrockets
 
 TrainerCooltrainermPaul:
 	trainer EVENT_BEAT_COOLTRAINERM_PAUL, COOLTRAINERM, PAUL, CooltrainermPaulSeenText, CooltrainermPaulBeatenText, 0, CooltrainermPaulScript

--- a/maps/CeladonGym.asm
+++ b/maps/CeladonGym.asm
@@ -35,6 +35,8 @@ ErikaScript_0x72a6a:
 	playsound SFX_GET_BADGE
 	waitsfx
 	setflag ENGINE_RAINBOWBADGE
+	checkcode VAR_BADGES
+	scall CeladonGymTriggerRockets
 .FightDone
 	checkevent EVENT_GOT_TM19_GIGA_DRAIN
 	iftrue UnknownScript_0x72aae
@@ -48,6 +50,17 @@ UnknownScript_0x72aae:
 	waitbutton
 	closetext
 	end
+
+CeladonGymTriggerRockets:
+	if_equal 7, .RadioTowerRockets
+	if_equal 6, .GoldenrodRockets
+	end
+
+.GoldenrodRockets
+	jumpstd goldenrodrockets
+
+.RadioTowerRockets
+	jumpstd radiotowerrockets
 
 TrainerLassMichelle:
 	trainer EVENT_BEAT_LASS_MICHELLE, LASS, MICHELLE, LassMichelleSeenText, LassMichelleBeatenText, 0, LassMichelleScript

--- a/maps/CeruleanGym.asm
+++ b/maps/CeruleanGym.asm
@@ -81,11 +81,24 @@ MistyScript_0x188432:
 	playsound SFX_GET_BADGE
 	waitsfx
 	setflag ENGINE_CASCADEBADGE
+	checkcode VAR_BADGES
+	scall CeruleanGymTriggerRockets
 .FightDone
 	writetext UnknownText_0x188782
 	waitbutton
 	closetext
 	end
+
+CeruleanGymTriggerRockets:
+	if_equal 7, .RadioTowerRockets
+	if_equal 6, .GoldenrodRockets
+	end
+
+.GoldenrodRockets
+	jumpstd goldenrodrockets
+
+.RadioTowerRockets
+	jumpstd radiotowerrockets
 
 TrainerSwimmerfDiana:
 	trainer EVENT_BEAT_SWIMMERF_DIANA, SWIMMERF, DIANA, SwimmerfDianaSeenText, SwimmerfDianaBeatenText, 0, SwimmerfDianaScript

--- a/maps/FuchsiaGym.asm
+++ b/maps/FuchsiaGym.asm
@@ -41,6 +41,8 @@ JanineScript_0x195db9:
 	playsound SFX_GET_BADGE
 	waitsfx
 	setflag ENGINE_SOULBADGE
+	checkcode VAR_BADGES
+	scall FuchsiaGymTriggerRockets
 	jump UnknownScript_0x195e02
 .FightDone
 	faceplayer
@@ -58,6 +60,17 @@ UnknownScript_0x195e15:
 	waitbutton
 	closetext
 	end
+
+FuchsiaGymTriggerRockets:
+	if_equal 7, .RadioTowerRockets
+	if_equal 6, .GoldenrodRockets
+	end
+
+.GoldenrodRockets
+	jumpstd goldenrodrockets
+
+.RadioTowerRockets
+	jumpstd radiotowerrockets
 
 FuschiaGym1Script_0x195e1b:
 	checkevent EVENT_BEAT_LASS_ALICE

--- a/maps/PewterGym.asm
+++ b/maps/PewterGym.asm
@@ -29,6 +29,8 @@ BrockScript_0x1a2864:
 	playsound SFX_GET_BADGE
 	waitsfx
 	setflag ENGINE_BOULDERBADGE
+	checkcode VAR_BADGES
+	scall PewterGymTriggerRockets
 	writetext UnknownText_0x1a2a57
 	waitbutton
 	closetext
@@ -39,6 +41,17 @@ BrockScript_0x1a2864:
 	waitbutton
 	closetext
 	end
+
+PewterGymTriggerRockets:
+	if_equal 7, .RadioTowerRockets
+	if_equal 6, .GoldenrodRockets
+	end
+
+.GoldenrodRockets
+	jumpstd goldenrodrockets
+
+.RadioTowerRockets
+	jumpstd radiotowerrockets
 
 TrainerCamperJerry:
 	trainer EVENT_BEAT_CAMPER_JERRY, CAMPER, JERRY, CamperJerrySeenText, CamperJerryBeatenText, 0, CamperJerryScript

--- a/maps/SaffronGym.asm
+++ b/maps/SaffronGym.asm
@@ -35,6 +35,8 @@ SabrinaScript_0x189c2e:
 	playsound SFX_GET_BADGE
 	waitsfx
 	setflag ENGINE_MARSHBADGE
+	checkcode VAR_BADGES
+	scall SaffronGymTriggerRockets
 	writetext UnknownText_0x189ead
 	waitbutton
 	closetext
@@ -45,6 +47,17 @@ SabrinaScript_0x189c2e:
 	waitbutton
 	closetext
 	end
+
+SaffronGymTriggerRockets:
+	if_equal 7, .RadioTowerRockets
+	if_equal 6, .GoldenrodRockets
+	end
+
+.GoldenrodRockets
+	jumpstd goldenrodrockets
+
+.RadioTowerRockets
+	jumpstd radiotowerrockets
 
 TrainerMediumRebecca:
 	trainer EVENT_BEAT_MEDIUM_REBECCA, MEDIUM, REBECCA, MediumRebeccaSeenText, MediumRebeccaBeatenText, 0, MediumRebeccaScript

--- a/maps/SeafoamGym.asm
+++ b/maps/SeafoamGym.asm
@@ -36,6 +36,8 @@ BlaineScript_0x1ab4fb:
 	playsound SFX_GET_BADGE
 	waitsfx
 	setflag ENGINE_VOLCANOBADGE
+	checkcode VAR_BADGES
+	scall SeafoamGymTriggerRockets
 	writetext UnknownText_0x1ab69d
 	waitbutton
 	closetext
@@ -46,6 +48,17 @@ BlaineScript_0x1ab4fb:
 	waitbutton
 	closetext
 	end
+
+SeafoamGymTriggerRockets:
+	if_equal 7, .RadioTowerRockets
+	if_equal 6, .GoldenrodRockets
+	end
+
+.GoldenrodRockets
+	jumpstd goldenrodrockets
+
+.RadioTowerRockets
+	jumpstd radiotowerrockets
 
 SeafoamGymGuyScript:
 	faceplayer

--- a/maps/VermilionGym.asm
+++ b/maps/VermilionGym.asm
@@ -33,6 +33,8 @@ SurgeScript_0x1920a5:
 	playsound SFX_GET_BADGE
 	waitsfx
 	setflag ENGINE_THUNDERBADGE
+	checkcode VAR_BADGES
+	scall VermilionGymTriggerRockets
 	writetext UnknownText_0x192291
 	waitbutton
 	closetext
@@ -43,6 +45,17 @@ SurgeScript_0x1920a5:
 	waitbutton
 	closetext
 	end
+
+VermilionGymTriggerRockets:
+	if_equal 7, .RadioTowerRockets
+	if_equal 6, .GoldenrodRockets
+	end
+
+.GoldenrodRockets
+	jumpstd goldenrodrockets
+
+.RadioTowerRockets
+	jumpstd radiotowerrockets
 
 TrainerGentlemanGregory:
 	trainer EVENT_BEAT_GENTLEMAN_GREGORY, GENTLEMAN, GREGORY, GentlemanGregorySeenText, GentlemanGregoryBeatenText, 0, GentlemanGregoryScript

--- a/maps/ViridianGym.asm
+++ b/maps/ViridianGym.asm
@@ -27,6 +27,8 @@ BlueScript_0x9aa26:
 	playsound SFX_GET_BADGE
 	waitsfx
 	setflag ENGINE_EARTHBADGE
+	checkcode VAR_BADGES
+	scall ViridianGymTriggerRockets
 	writetext LeaderBlueAfterText
 	waitbutton
 	closetext
@@ -37,6 +39,17 @@ BlueScript_0x9aa26:
 	waitbutton
 	closetext
 	end
+
+ViridianGymTriggerRockets:
+	if_equal 7, .RadioTowerRockets
+	if_equal 6, .GoldenrodRockets
+	end
+
+.GoldenrodRockets
+	jumpstd goldenrodrockets
+
+.RadioTowerRockets
+	jumpstd radiotowerrockets
 
 ViridianGymGuyScript:
 	faceplayer

--- a/text/phone/elm.asm
+++ b/text/phone/elm.asm
@@ -159,30 +159,14 @@ ElmPhoneEggAssistantText: ; 0x1b4b87
 	done
 
 ElmPhoneRocketText: ; 0x1b4c06
-	text "<PLAY_G>, how are"
-	line "things going?"
-
-	para "I called because"
-	line "something weird is"
-
-	para "happening with the"
-	line "radio broadcasts."
+	text "Have you heard the"
+	line "radio broadcasts?"
 
 	para "They were talking"
 	line "about TEAM ROCKET."
 
-	para "<PLAY_G>, do you"
-	line "know anything"
-	cont "about it?"
-
 	para "Maybe TEAM ROCKET"
-	line "has returned. No,"
-
-	para "that just can't"
-	line "be true."
-
-	para "Sorry to bug you."
-	line "Take care!"
+	line "has returned..."
 	done
 
 ElmPhoneGiftText: ; 0x1b4d09


### PR DESCRIPTION
tl;dr
* check to trigger team rocket after every badge, instead of just the first 7 johto badges (as in vanilla)
* shorten Elm's call about the radio tower takeover

i'm working on a [key item randomizer for crystal](https://github.com/pclalv/crystal-key-item-randomizer), and popular demand indicates that it should support crystal speedchoice. currently, one of the complexities i'm facing is around how to handle the Radio Tower takeover; as is, a randomizer player can hardlock themselves if they acquire badges in the correct order, namely if their 7th badge is not one of the first 7 johto badges. rather than have to teach the randomizer to patch in this code, i was hoping we might just bake it into the speedchoice ROM. i think that this change is unobtrusive given that the speedchoice team has already patched the radio tower takeover for the rocketless option; on the plus side, most players won't even realize that there's been a change, and the key item randomizer will be more maintainable.