### PR TITLE
Update Pokecrystal-speedchoice to work with modern RGBDS versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,8 @@ clean:
 %.o: %.asm $$(dep)
 	$(ASM) -o $@ $<
 
-crystal-speedchoice.gbc: $(crystal_obj)
-	$(LD) -n crystal-speedchoice.sym -m crystal-speedchoice.map -o $@ $^
+crystal-speedchoice.gbc: $(crystal_obj) crystal-speedchoice.link
+	$(LD) -n crystal-speedchoice.sym -m crystal-speedchoice.map -l crystal-speedchoice.link -o $@ $(crystal_obj)
 	$(FIX) -Cjv -i KAPB -k 01 -l 0x33 -m 0x10 -p 0 -n 4 -r 3 -t PM_CRYSTAL $@
 
 %.png: ;

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -230,7 +230,7 @@ UpdateChannels: ; e8125
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 
 .ChannelFnPtrs
@@ -1394,7 +1394,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; e8720
 

--- a/battle/ai/items.asm
+++ b/battle/ai/items.asm
@@ -211,7 +211,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 .callback
 	pop de
 	pop hl

--- a/battle/ai/redundant.asm
+++ b/battle/ai/redundant.asm
@@ -11,7 +11,7 @@ AI_Redundant: ; 2c41a
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Moves: ; 2c42c
 	dbw EFFECT_DREAM_EATER,  .DreamEater

--- a/battle/anim_commands.asm
+++ b/battle/anim_commands.asm
@@ -347,7 +347,7 @@ RunBattleAnimCommand: ; cc25f
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; cc2a4
 
 

--- a/battle/bg_effects.asm
+++ b/battle/bg_effects.asm
@@ -75,7 +75,7 @@ DoBattleBGEffectFunction: ; c804a (32:404a)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 BattleBGEffects: ; c805a (32:405a)
 	dw BattleBGEffect_End
@@ -161,7 +161,7 @@ BattleBGEffects_AnonJumptable: ; c80d7 (32:40d7)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 BattleBGEffects_IncrementJumptable: ; c80e5 (32:40e5)
 	ld hl, BG_EFFECT_STRUCT_JT_INDEX
@@ -2059,7 +2059,7 @@ BattleBGEffect_1c: ; c8b00 (32:4b00)
 .cgb
 	ld de, .Jumptable
 	call BatttleBGEffects_GetNamedJumptablePointer
-	jp [hl]
+	jp hl
 
 .Jumptable
 	dw .cgb_zero
@@ -2421,7 +2421,7 @@ BGEffect_RapidCyclePals: ; c8d77 (32:4d77)
 	ld de, .Jumptable_DMG
 	call BatttleBGEffects_GetNamedJumptablePointer
 	pop de
-	jp [hl]
+	jp hl
 
 .Jumptable_DMG
 	dw .zero_dmg
@@ -2484,7 +2484,7 @@ BGEffect_RapidCyclePals: ; c8d77 (32:4d77)
 	ld de, .Jumptable_CGB
 	call BatttleBGEffects_GetNamedJumptablePointer
 	pop de
-	jp [hl]
+	jp hl
 
 .Jumptable_CGB: ; c8ddd (32:4ddd)
 	dw .zero_cgb

--- a/battle/core.asm
+++ b/battle/core.asm
@@ -4400,7 +4400,7 @@ SpikesDamage: ; 3dc23
 	jp WaitBGMap
 
 .hl
-	jp [hl]
+	jp hl
 ; 3dc5b
 
 PursuitSwitch: ; 3dc5b

--- a/battle/effect_commands.asm
+++ b/battle/effect_commands.asm
@@ -113,7 +113,7 @@ DoMove: ; 3402c
 	jr .ReadMoveEffectCommand
 
 .DoMoveEffectCommand
-	jp [hl]
+	jp hl
 
 ; 34084
 

--- a/battle/objects/functions.asm
+++ b/battle/objects/functions.asm
@@ -9,7 +9,7 @@ DoBattleAnimFrame: ; ccfbe
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; ccfce
 
 .Jumptable
@@ -4049,7 +4049,7 @@ BattleAnim_AnonJumptable: ; ce71e (33:671e)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 BattleAnim_IncAnonJumptableIndex: ; ce72c (33:672c)
 	ld hl, BATTLEANIMSTRUCT_ANON_JT_INDEX

--- a/crystal-speedchoice.link
+++ b/crystal-speedchoice.link
@@ -31,9 +31,9 @@ ROM0
 ROMX $01
 	"bank1"
 	"movenamesnerfed"
+	"femon"
 	"rbsfx"
 	"lrtrainercheck"
-	"femon"
 ROMX $02
 	"bank2"
 	"statsdisplay"
@@ -317,6 +317,7 @@ ROMX $7e
 	"bank7E"
 ROMX $7f
 	"bank7F"
+	org $7DE0
 	"stadium2"
 WRAM0
 	"Stack"

--- a/crystal-speedchoice.link
+++ b/crystal-speedchoice.link
@@ -1,0 +1,364 @@
+ROM0
+	org $0000
+	"NULL"
+	"rst0"
+	org $0008
+	"rst8"
+	org $0010
+	"rst10"
+	org $0018
+	"rst18"
+	org $0020
+	"rst20"
+	org $0028
+	"rst28"
+	org $0038
+	"rst38"
+	org $0040
+	"vblank"
+	org $0048
+	"lcd"
+	org $0050
+	"timer"
+	org $0058
+	"serial"
+	org $0060
+	"joypad"
+	org $0100
+	"Header"
+	org $0150
+	"Home"
+ROMX $01
+	"bank1"
+	"movenamesnerfed"
+	"rbsfx"
+	"lrtrainercheck"
+	"femon"
+ROMX $02
+	"bank2"
+	"statsdisplay"
+ROMX $03
+	"bank3"
+	"bwxp"
+ROMX $04
+	"bank4"
+ROMX $05
+	"bank5"
+	"permaoptionsintro"
+	"stats"
+ROMX $06
+	"Tileset Data 1"
+ROMX $07
+	"Roofs"
+	"Tileset Data 2"
+	"Extra Songs 1"
+ROMX $08
+	"bank8"
+	"Tileset Data 3"
+	"Egg Moves"
+ROMX $09
+	"bank9"
+ROMX $0a
+	"bankA"
+ROMX $0b
+	"bankB"
+	"monmoves"
+ROMX $0c
+	"Tileset Data 4"
+ROMX $0d
+	"Effect Commands"
+ROMX $0e
+	"Enemy Trainers"
+ROMX $0f
+	"Battle Core"
+ROMX $10
+	"bank10"
+	"Evolutions and Attacks"
+ROMX $11
+	"bank11"
+ROMX $12
+	"Crystal Unique"
+ROMX $13
+	"bank13"
+ROMX $14
+	"bank14"
+ROMX $15
+	"Map Scripts 1"
+ROMX $16
+	"Map Scripts 2"
+ROMX $17
+	"Map Scripts 3"
+ROMX $18
+	"Map Scripts 4"
+ROMX $19
+	"bank19"
+ROMX $1a
+	"Map Scripts 5"
+ROMX $1b
+	"Map Scripts 6"
+ROMX $1c
+	"Map Scripts 7"
+ROMX $1d
+	"Map Scripts 8"
+ROMX $1e
+	"Map Scripts 9"
+ROMX $1f
+	"Map Scripts 10"
+ROMX $20
+	"bank20"
+ROMX $21
+	"bank21"
+ROMX $22
+	"bank22"
+ROMX $23
+	"bank23"
+ROMX $24
+	"bank24"
+ROMX $25
+	"Map Headers"
+	"Events"
+ROMX $26
+	"Map Scripts 11"
+ROMX $27
+	"Map Scripts 12"
+ROMX $28
+	"Phone Engine"
+ROMX $29
+	"Phone Text"
+ROMX $2a
+	"Map Blockdata 1"
+ROMX $2b
+	"Map Blockdata 2"
+ROMX $2c
+	"Map Blockdata 3"
+ROMX $2d
+	"Tileset Data 5"
+ROMX $2e
+	"bank2E"
+ROMX $2f
+	"bank2F"
+ROMX $30
+	"bank30"
+ROMX $31
+	"bank31"
+ROMX $32
+	"bank32"
+ROMX $33
+	"bank33"
+	"Extra Songs 2"
+ROMX $34
+	"Pic Animations 1"
+ROMX $35
+	"Pic Animations 2"
+ROMX $36
+	"bank36"
+	"Pic Animations 3"
+ROMX $37
+	"Tileset Data 6"
+ROMX $38
+	"bank38"
+ROMX $39
+	"bank39"
+ROMX $3a
+	"Audio"
+	"Songs 1"
+ROMX $3b
+	"Songs 2"
+ROMX $3c
+	"Songs 3"
+	"Sound Effects"
+	"Cries"
+ROMX $3d
+	"Songs 4"
+ROMX $3e
+	"bank3E"
+ROMX $3f
+	"bank3F"
+ROMX $40
+	"bank40"
+	"tetsuji"
+	"bank40_2"
+	"ascii 10186f"
+	"bank40_3"
+ROMX $41
+	"bank41"
+	"bank41_2"
+ROMX $42
+	"bank42"
+	"Intro Logo"
+	"Credits"
+ROMX $43
+	"bank43"
+ROMX $44
+	"Main"
+ROMX $45
+	"bank45"
+	"Mobile Stadium"
+ROMX $46
+	"bank46"
+	"bank46_2"
+ROMX $47
+	"bank47"
+ROMX $48
+	"Pic Pointers"
+	"Pics 1"
+ROMX $49
+	"Unown Pic Pointers"
+	"Pics 2"
+ROMX $4a
+	"Trainer Pic Pointers"
+	"Pics 3"
+ROMX $4b
+	"Pics 4"
+ROMX $4c
+	"Pics 5"
+ROMX $4d
+	"Pics 6"
+ROMX $4e
+	"Pics 7"
+ROMX $4f
+	"Pics 8"
+ROMX $50
+	"Pics 9"
+ROMX $51
+	"Pics 10"
+ROMX $52
+	"Pics 11"
+ROMX $53
+	"Pics 12"
+ROMX $54
+	"Pics 13"
+ROMX $55
+	"Pics 14"
+ROMX $56
+	"Pics 15"
+ROMX $57
+	"Pics 16"
+ROMX $58
+	"Pics 17"
+ROMX $59
+	"Pics 18"
+ROMX $5a
+	"Pics 19"
+ROMX $5b
+	"bank5B"
+ROMX $5c
+	"bank5C"
+ROMX $5d
+	"bank5D"
+ROMX $5e
+	"bank5E"
+	"Songs 5"
+	"Crystal Sound Effects"
+	"Misc Crystal"
+ROMX $5f
+	"bank5F"
+ROMX $60
+	"Map Scripts 13"
+	"Pokedex Entries 001-064"
+ROMX $61
+	"Map Scripts 14"
+ROMX $62
+	"Map Scripts 15"
+ROMX $63
+	"Map Scripts 16"
+ROMX $64
+	"Map Scripts 17"
+ROMX $65
+	"Map Scripts 18"
+ROMX $66
+	"Map Scripts 19"
+ROMX $67
+	"Map Scripts 20"
+ROMX $68
+	"Map Scripts 21"
+ROMX $69
+	"Map Scripts 22"
+ROMX $6a
+	"Map Scripts 23"
+ROMX $6b
+	"Map Scripts 24"
+ROMX $6c
+	"Common Text 1"
+	"Map Scripts 25"
+ROMX $6d
+	"bank6D"
+ROMX $6e
+	"Pokedex Entries 065-128"
+ROMX $6f
+	"Text 1"
+ROMX $70
+	"Text 2"
+ROMX $71
+	"Text 3"
+ROMX $72
+	"bank72"
+ROMX $73
+	"Pokedex Entries 129-192"
+ROMX $74
+	"Pokedex Entries 193-251"
+ROMX $75
+ROMX $76
+ROMX $77
+	"bank77"
+	"Tileset Data 7"
+	"bank77_2"
+ROMX $78
+	"Tileset Data 8"
+ROMX $79
+ROMX $7a
+ROMX $7b
+	"bank7B"
+ROMX $7c
+	"bank7C"
+ROMX $7d
+	"bank7D"
+ROMX $7e
+	"bank7E"
+ROMX $7f
+	"bank7F"
+	"stadium2"
+WRAM0
+	"Stack"
+	"AudioWRAM"
+	"WRAM"
+	"wSpriteAnims"
+	"Sprites"
+	"Tilemap"
+	"Battle"
+	"Overworld Map"
+	"Video"
+WRAMX $01
+	"WRAM 1"
+	"Enemy Party"
+	"Party"
+WRAMX $02
+	"Pic Animations"
+WRAMX $03
+	"Battle Tower"
+WRAMX $04
+	"Aligned Tile Map"
+WRAMX $05
+	"GBC Video"
+	"Battle Animations"
+	"WRAM 5 MOBILE"
+WRAMX $06
+	"WRAM 6"
+WRAMX $07
+	"WRAM 7"
+VRAM $00
+	"VRAM0"
+VRAM $01
+	"VRAM1"
+SRAM $00
+	"Scratch"
+	"SRAM Bank 0"
+	"Backup Save"
+SRAM $01
+	"SRAM Bank 1"
+	"SRAM Battle Tower"
+	"SRAM Speedchoice Stats"
+SRAM $02
+	"Boxes 1-7"
+SRAM $03
+	"Boxes 8-14"

--- a/crystal-speedchoice.link
+++ b/crystal-speedchoice.link
@@ -323,6 +323,7 @@ WRAM0
 	"AudioWRAM"
 	"WRAM"
 	"wSpriteAnims"
+	align 8
 	"Sprites"
 	"Tilemap"
 	"Battle"
@@ -340,7 +341,9 @@ WRAMX $04
 	"Aligned Tile Map"
 WRAMX $05
 	"GBC Video"
+	org $d300
 	"Battle Animations"
+	org $d800
 	"WRAM 5 MOBILE"
 WRAMX $06
 	"WRAM 6"
@@ -352,7 +355,9 @@ VRAM $01
 	"VRAM1"
 SRAM $00
 	"Scratch"
+	org $a600
 	"SRAM Bank 0"
+	org $b200
 	"Backup Save"
 SRAM $01
 	"SRAM Bank 1"

--- a/engine/billspc.asm
+++ b/engine/billspc.asm
@@ -39,7 +39,7 @@ _DepositPKMN: ; e2391 (38:6391)
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call BillsPC_Jumptable
-	jp [hl]
+	jp hl
 
 .Jumptable: ; e23df (38:63df)
 	
@@ -148,7 +148,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 BillsPCDepositJumptable: ; e24a1 (38:64a1)
 	
@@ -307,7 +307,7 @@ _WithdrawPKMN: ; e2583 (38:6583)
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call BillsPC_Jumptable
-	jp [hl]
+	jp hl
 
 .Jumptable: ; e25d2 (38:65d2)
 	
@@ -417,7 +417,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .dw: ; e2699 (38:6699) #mark
 	dw .withdraw ; Withdraw
@@ -558,7 +558,7 @@ _MovePKMNWithoutMail: ; e2759
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call BillsPC_Jumptable
-	jp [hl]
+	jp hl
 ; e27ac
 
 .Jumptable: ; e27ac
@@ -681,7 +681,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e2881
 
 .Jumptable2: ; e2881
@@ -2018,7 +2018,7 @@ endr
 	ld l, a
 	ld de, .dw_return
 	push de
-	jp [hl]
+	jp hl
 ; e322a
 
 .dw_return: ; e322a

--- a/engine/card_flip.asm
+++ b/engine/card_flip.asm
@@ -77,7 +77,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e01a0 (38:41a0)
 
 .Jumptable: ; e01a0
@@ -655,7 +655,7 @@ CardFlip_BlankDiscardedCardSlot: ; e0534
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e0553
 
 .Jumptable: ; e0553
@@ -844,7 +844,7 @@ CardFlip_CheckWinCondition: ; e0637
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e0643
 
 .Jumptable: ; e0643

--- a/engine/credits.asm
+++ b/engine/credits.asm
@@ -264,7 +264,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 109937
 
 

--- a/engine/crystal_intro.asm
+++ b/engine/crystal_intro.asm
@@ -124,7 +124,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e467f
 
 .dw: ; e467f
@@ -222,7 +222,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 GameFreakLogoScenes: ; e46fd (39:46fd)
 	dw GameFreakLogoScene1
@@ -440,7 +440,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e491e
 
 IntroScenes: ; e491e (39:491e)

--- a/engine/debug.asm
+++ b/engine/debug.asm
@@ -306,7 +306,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .asm_81a9a
 	call Function81eca
@@ -615,7 +615,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .asm_81cdf
 	ld a, $4
@@ -1362,7 +1362,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 82301
 
 .dw: ; 82301

--- a/engine/events.asm
+++ b/engine/events.asm
@@ -611,7 +611,7 @@ TryObjectEvent: ; 969b5
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .nope_bugged
 	; pop bc

--- a/engine/intro_menu.asm
+++ b/engine/intro_menu.asm
@@ -1036,7 +1036,7 @@ StartTitleScreen: ; 6219
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 626a
 
 .dw
@@ -1089,7 +1089,7 @@ TitleScreenScene: ; 62a3
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 62af
 
 .scenes

--- a/engine/map_objects.asm
+++ b/engine/map_objects.asm
@@ -1970,7 +1970,7 @@ JumpMovementPointer: ; 505e
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 5065
 
 ContinueReadingMovement: ; 5065

--- a/engine/mon_icons.asm
+++ b/engine/mon_icons.asm
@@ -34,7 +34,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 8e854
 
 

--- a/engine/namingscreen.asm
+++ b/engine/namingscreen.asm
@@ -71,7 +71,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; 1172e
 
@@ -407,7 +407,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; 11977
 
@@ -1170,7 +1170,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable: ; 12017 (4:6017)
 	dw .init_blinking_cursor

--- a/engine/options_menu.asm
+++ b/engine/options_menu.asm
@@ -176,7 +176,7 @@ endr
 	ld h, [hl]
 	ld l, a
 	ld a, [hJoyPressed] ; almost all options use this, so it's easier to just do it here
-	jp [hl] ; jump to the code of the current highlighted item
+	jp hl ; jump to the code of the current highlighted item
 ; e42e5
 
 Options_Cancel: ; e4520

--- a/engine/pack.asm
+++ b/engine/pack.asm
@@ -23,7 +23,7 @@ Pack: ; 10000
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 10030
 
@@ -144,7 +144,7 @@ Pack: ; 10000
 	ld a, [wMenuCursorY]
 	dec a
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 10124 (4:4124)
 .MenuDataHeader1: ; 0x10124
@@ -306,7 +306,7 @@ Pack: ; 10000
 	ld a, [wMenuCursorY]
 	dec a
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 10249 (4:4249)
 MenuDataHeader_UsableKeyItem: ; 0x10249
@@ -689,7 +689,7 @@ BattlePack: ; 10493
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 104c3
 
@@ -846,7 +846,7 @@ TMHMSubmenu: ; 105dc (4:45dc)
 	ld a, [wMenuCursorY]
 	dec a
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 10601 (4:4601)
 .UsableMenuDataHeader: ; 0x10601
@@ -997,7 +997,7 @@ DepositSellPack: ; 106be
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 106d1
 
@@ -1144,7 +1144,7 @@ TutorialPack: ; 107bb
 	ld a, [wJumptableIndex]
 	ld hl, .dw
 	call Pack_GetJumptablePointer
-	jp [hl]
+	jp hl
 
 ; 107e1
 

--- a/engine/pokedex.asm
+++ b/engine/pokedex.asm
@@ -182,7 +182,7 @@ Pokedex_RunJumptable: ; 4010b
 	ld a, [wJumptableIndex]
 	ld hl, .Jumptable
 	call Pokedex_LoadPointer
-	jp [hl]
+	jp hl
 
 
 .Jumptable: ; 40115 (10:4115)
@@ -366,7 +366,7 @@ Pokedex_UpdateDexEntryScreen: ; 40258 (10:4258)
 	ld a, [wDexArrowCursorPosIndex]
 	ld hl, DexEntryScreen_MenuActionJumptable
 	call Pokedex_LoadPointer
-	jp [hl]
+	jp hl
 
 .return_to_prev_screen
 	ld a, [LastVolume]
@@ -545,7 +545,7 @@ Pokedex_UpdateOptionScreen: ; 403be (10:43be)
 	ld a, [wDexArrowCursorPosIndex]
 	ld hl, .MenuActionJumptable
 	call Pokedex_LoadPointer
-	jp [hl]
+	jp hl
 
 .return_to_main_screen
 	call Pokedex_BlackOutBG
@@ -647,7 +647,7 @@ Pokedex_UpdateSearchScreen: ; 40471 (10:4471)
 	ld a, [wDexArrowCursorPosIndex]
 	ld hl, .MenuActionJumptable
 	call Pokedex_LoadPointer
-	jp [hl]
+	jp hl
 
 .cancel
 	call Pokedex_BlackOutBG
@@ -1621,7 +1621,7 @@ Pokedex_OrderMonsByMode: ; 40bdc
 	ld a, [wCurrentDexMode]
 	ld hl, .Jumptable
 	call Pokedex_LoadPointer
-	jp [hl]
+	jp hl
 
 
 .Jumptable: ; 40bf0 (10:4bf0)

--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -235,7 +235,7 @@ InitPokegearTilemap: ; 90da8 (24:4da8)
 	ld l, a
 	ld de, .return_from_jumptable
 	push de
-	jp [hl]
+	jp hl
 
 .return_from_jumptable
 	call Pokegear_FinishTilemap
@@ -431,7 +431,7 @@ PokegearJumptable: ; 90f04 (24:4f04)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable: ; 90f13 (24:4f13)
 	dw PokegearClock_Init
@@ -1217,7 +1217,7 @@ PokegearPhoneContactSubmenu: ; 91342 (24:5342)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Cancel: ; 913f1
 	ld hl, PokegearText_WhomToCall
@@ -1484,7 +1484,7 @@ UpdateRadioStation: ; 9166f (24:566f)
 	ld l, a
 	ld de, .returnafterstation
 	push de
-	jp [hl]
+	jp hl
 
 .returnafterstation
 	ld a, [wPokegearRadioChannelBank]
@@ -2043,7 +2043,7 @@ PlayRadio: ; 91a53
 	ld l, a
 	ld de, .jump_return
 	push de
-	jp [hl]
+	jp hl
 
 .jump_return
 	push de

--- a/engine/printer.asm
+++ b/engine/printer.asm
@@ -27,7 +27,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 84031
 
 
@@ -438,7 +438,7 @@ _PrinterReceive:: ; 842db
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 842ea
 
 

--- a/engine/radio.asm
+++ b/engine/radio.asm
@@ -25,7 +25,7 @@ PlayRadioShow:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 RadioJumptable:
 	dw OaksPkmnTalk1  ; $00

--- a/engine/slot_machine.asm
+++ b/engine/slot_machine.asm
@@ -796,7 +796,7 @@ Function92bd4: ; 92bd4 (24:6bd4)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; 92be4 (24:6be4)
 
@@ -1311,7 +1311,7 @@ Slots_CheckMatchedFirstTwoReels: ; 92e94
 	ld l, a
 	ld de, .return
 	push de
-	jp [hl]
+	jp hl
 
 .return
 	ld a, [wFirstTwoReelsMatching]
@@ -1422,7 +1422,7 @@ Slots_CheckMatchedAllThreeReels: ; 92f1d
 	ld l, a
 	ld de, .return
 	push de
-	jp [hl]
+	jp hl
 
 .return
 	ld a, [wSlotMatched]
@@ -1855,7 +1855,7 @@ endr
 	ld l, a
 	ld de, .return
 	push de
-	jp [hl]
+	jp hl
 
 .return
 	ld hl, .Text_PrintPayout
@@ -1958,7 +1958,7 @@ SlotMachine_AnimateGolem: ; 9321d (24:721d)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable: ; 9322d (24:722d)
 	
@@ -2059,7 +2059,7 @@ Slots_AnimateChansey: ; 932ac (24:72ac)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable: ; 932bc (24:72bc)
 	

--- a/engine/sprite_anims.asm
+++ b/engine/sprite_anims.asm
@@ -9,7 +9,7 @@ DoAnimFrame: ; 8d24b
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 8d25b
 
 .Jumptable: ; 8d25b (23:525b)
@@ -134,7 +134,7 @@ DoAnimFrame: ; 8d24b
 
 .four: ; 8d302 (23:5302)
 	call .anonymous_dw
-	jp [hl]
+	jp hl
 ; 8d306 (23:5306)
 
 ; Anonymous dw (see .anonymous_dw)
@@ -418,7 +418,7 @@ DoAnimFrame: ; 8d24b
 
 .sixteen: ; 8d483 (23:5483)
 	call .anonymous_dw
-	jp [hl]
+	jp hl
 ; 8d487 (23:5487)
 
 ; Anonymous dw (see .anonymous_dw)
@@ -855,7 +855,7 @@ endr
 	ret
 
 .anonymous_dw: ; 8d6c5 (23:56c5)
-	ld hl, [sp+$0]
+	ld hl, sp+$0
 	ld e, [hl]
 	inc hl
 	ld d, [hl]

--- a/engine/startmenu.asm
+++ b/engine/startmenu.asm
@@ -57,7 +57,7 @@ StartMenu:: ; 125cd
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .MenuReturns
 	dw .Reopen
@@ -234,7 +234,7 @@ StartMenu:: ; 125cd
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 127ef
 
 .MenuString ; 127ef
@@ -749,7 +749,7 @@ PokemonActionSubmenu: ; 12a88
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .nothing
 	ld a, 0

--- a/engine/timeofdaypals.asm
+++ b/engine/timeofdaypals.asm
@@ -251,7 +251,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 8c126
 
 .TimePalettes

--- a/engine/trade/animation.asm
+++ b/engine/trade/animation.asm
@@ -230,7 +230,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 290af
 
 .JumpTable: ; 290af
@@ -525,7 +525,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 2928f
 
 Jumptable_2928f: ; 2928f
@@ -1111,7 +1111,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 29686
 
 Jumptable_29686: ; 29686 (a:5686)

--- a/engine/trade/animation.asm
+++ b/engine/trade/animation.asm
@@ -1166,7 +1166,7 @@ Function296bd: ; 296bd (a:56bd)
 	inc [hl]
 	ret
 .asm_296c8
-	ld hl, $
+	ld hl, $0
 	add hl, bc
 	ld [hl], $0
 	ret
@@ -1204,7 +1204,7 @@ Function296f2: ; 296f2 (a:56f2)
 	dec [hl]
 	and a
 	ret nz
-	ld hl, $
+	ld hl, $0
 	add hl, bc
 	ld [hl], $0
 	ret

--- a/engine/unown_puzzle.asm
+++ b/engine/unown_puzzle.asm
@@ -184,7 +184,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; e12d9
 
 .Jumptable: ; e12d9

--- a/event/field_moves.asm
+++ b/event/field_moves.asm
@@ -170,7 +170,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 8ca1b
 
 

--- a/event/magnet_train.asm
+++ b/event/magnet_train.asm
@@ -304,7 +304,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 8ce06
 
 .Jumptable: ; 8ce06

--- a/event/mom.asm
+++ b/event/mom.asm
@@ -29,7 +29,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 16242
 
 .dw: ; 16242

--- a/gfx/mail.asm
+++ b/gfx/mail.asm
@@ -108,7 +108,7 @@ endr
 	ld de, .done
 	pop bc
 	push de
-	jp [hl]
+	jp hl
 .done
 	ret
 ; b92f8

--- a/gfx/pics.asm
+++ b/gfx/pics.asm
@@ -3,19 +3,19 @@ INCLUDE "includes.asm"
 
 ; Unown pic pointers are assumed to start at the same address in a different bank.
 
-SECTION "Pic Pointers", ROMX[$4000], BANK[PIC_POINTERS]
+SECTION "Pic Pointers", ROMX
 PicPointers:: INCLUDE "gfx/pics/pic_pointers.asm"
 
-SECTION "Unown Pic Pointers", ROMX[$4000], BANK[UNOWN_PIC_POINTERS]
+SECTION "Unown Pic Pointers", ROMX
 UnownPicPointers:: INCLUDE "gfx/pics/unown_pic_pointers.asm"
 
 
-SECTION "Trainer Pic Pointers", ROMX, BANK[TRAINER_PIC_POINTERS]
+SECTION "Trainer Pic Pointers", ROMX
 TrainerPicPointers:: INCLUDE "gfx/pics/trainer_pic_pointers.asm"
 
 
 
-SECTION "Pics 1", ROMX, BANK[PICS_1]
+SECTION "Pics 1", ROMX
 
 HoOhFrontpic:        INCBIN "gfx/pics/ho_oh/front.2bpp.lz"
 MachampFrontpic:     INCBIN "gfx/pics/machamp/front.2bpp.lz"
@@ -33,7 +33,7 @@ TyphlosionFrontpic:  INCBIN "gfx/pics/typhlosion/front.2bpp.lz"
 ; 123ffa
 
 
-SECTION "Pics 2", ROMX, BANK[PICS_2]
+SECTION "Pics 2", ROMX
 
 BlastoiseFrontpic:   INCBIN "gfx/pics/blastoise/front.2bpp.lz"
 RapidashFrontpic:    INCBIN "gfx/pics/rapidash/front.2bpp.lz"
@@ -54,7 +54,7 @@ QuilavaFrontpic:     INCBIN "gfx/pics/quilava/front.2bpp.lz"
 ; 127ffe
 
 
-SECTION "Pics 3", ROMX, BANK[PICS_3]
+SECTION "Pics 3", ROMX
 
 SteelixFrontpic:     INCBIN "gfx/pics/steelix/front.2bpp.lz"
 AlakazamFrontpic:    INCBIN "gfx/pics/alakazam/front.2bpp.lz"
@@ -77,7 +77,7 @@ OmastarBackpic:      INCBIN "gfx/pics/omastar/back.2bpp.lz"
 ; 12bffe
 
 
-SECTION "Pics 4", ROMX, BANK[PICS_4]
+SECTION "Pics 4", ROMX
 
 DodrioFrontpic:      INCBIN "gfx/pics/dodrio/front.2bpp.lz"
 SlowkingFrontpic:    INCBIN "gfx/pics/slowking/front.2bpp.lz"
@@ -102,7 +102,7 @@ UnownEFrontpic:      INCBIN "gfx/pics/unown_e/front.2bpp.lz"
 ; 130000
 
 
-SECTION "Pics 5", ROMX, BANK[PICS_5]
+SECTION "Pics 5", ROMX
 
 GolbatFrontpic:      INCBIN "gfx/pics/golbat/front.2bpp.lz"
 KinglerFrontpic:     INCBIN "gfx/pics/kingler/front.2bpp.lz"
@@ -128,7 +128,7 @@ HeracrossFrontpic:   INCBIN "gfx/pics/heracross/front.2bpp.lz"
 ; 133fff
 
 
-SECTION "Pics 6", ROMX, BANK[PICS_6]
+SECTION "Pics 6", ROMX
 
 AriadosFrontpic:     INCBIN "gfx/pics/ariados/front.2bpp.lz"
 NoctowlFrontpic:     INCBIN "gfx/pics/noctowl/front.2bpp.lz"
@@ -156,7 +156,7 @@ DunsparceFrontpic:   INCBIN "gfx/pics/dunsparce/front.2bpp.lz"
 ; 137fff
 
 
-SECTION "Pics 7", ROMX, BANK[PICS_7]
+SECTION "Pics 7", ROMX
 
 VaporeonFrontpic:    INCBIN "gfx/pics/vaporeon/front.2bpp.lz"
 GirafarigFrontpic:   INCBIN "gfx/pics/girafarig/front.2bpp.lz"
@@ -186,7 +186,7 @@ KangaskhanBackpic:   INCBIN "gfx/pics/kangaskhan/back.2bpp.lz"
 ; 13c000
 
 
-SECTION "Pics 8", ROMX, BANK[PICS_8]
+SECTION "Pics 8", ROMX
 
 SeelFrontpic:        INCBIN "gfx/pics/seel/front.2bpp.lz"
 CrobatFrontpic:      INCBIN "gfx/pics/crobat/front.2bpp.lz"
@@ -218,7 +218,7 @@ QuagsireFrontpic:    INCBIN "gfx/pics/quagsire/front.2bpp.lz"
 ; 13fff7
 
 
-SECTION "Pics 9", ROMX, BANK[PICS_9]
+SECTION "Pics 9", ROMX
 
 EkansFrontpic:       INCBIN "gfx/pics/ekans/front.2bpp.lz"
 SudowoodoFrontpic:   INCBIN "gfx/pics/sudowoodo/front.2bpp.lz"
@@ -254,7 +254,7 @@ ParasectBackpic:     INCBIN "gfx/pics/parasect/back.2bpp.lz"
 ; 144000
 
 
-SECTION "Pics 10", ROMX, BANK[PICS_10]
+SECTION "Pics 10", ROMX
 
 MisdreavusFrontpic:  INCBIN "gfx/pics/misdreavus/front.2bpp.lz"
 HoundourFrontpic:    INCBIN "gfx/pics/houndour/front.2bpp.lz"
@@ -294,7 +294,7 @@ UnownFBackpic:       INCBIN "gfx/pics/unown_f/back.2bpp.lz"
 ; 148000
 
 
-SECTION "Pics 11", ROMX, BANK[PICS_11]
+SECTION "Pics 11", ROMX
 
 DodrioBackpic:       INCBIN "gfx/pics/dodrio/back.2bpp.lz"
 ClefairyFrontpic:    INCBIN "gfx/pics/clefairy/front.2bpp.lz"
@@ -337,7 +337,7 @@ SnorlaxBackpic:      INCBIN "gfx/pics/snorlax/back.2bpp.lz"
 ; 14bffb
 
 
-SECTION "Pics 12", ROMX, BANK[PICS_12]
+SECTION "Pics 12", ROMX
 
 VenusaurBackpic:     INCBIN "gfx/pics/venusaur/back.2bpp.lz"
 MoltresBackpic:      INCBIN "gfx/pics/moltres/back.2bpp.lz"
@@ -383,7 +383,7 @@ StarmieBackpic:      INCBIN "gfx/pics/starmie/back.2bpp.lz"
 ; 150000
 
 
-SECTION "Pics 13", ROMX, BANK[PICS_13]
+SECTION "Pics 13", ROMX
 
 OmanyteBackpic:      INCBIN "gfx/pics/omanyte/back.2bpp.lz"
 PidgeyBackpic:       INCBIN "gfx/pics/pidgey/back.2bpp.lz"
@@ -431,7 +431,7 @@ ElectrodeFrontpic:   INCBIN "gfx/pics/electrode/front.2bpp.lz"
 ; 153fe3
 
 
-SECTION "Pics 14", ROMX, BANK[PICS_14]
+SECTION "Pics 14", ROMX
 
 SudowoodoBackpic:    INCBIN "gfx/pics/sudowoodo/back.2bpp.lz"
 FlaaffyBackpic:      INCBIN "gfx/pics/flaaffy/back.2bpp.lz"
@@ -482,7 +482,7 @@ SwinubBackpic:       INCBIN "gfx/pics/swinub/back.2bpp.lz"
 ; 158000
 
 
-SECTION "Pics 15", ROMX, BANK[PICS_15]
+SECTION "Pics 15", ROMX
 
 MewtwoBackpic:       INCBIN "gfx/pics/mewtwo/back.2bpp.lz"
 PokemonProfPic:      INCBIN "gfx/trainers/oak.2bpp.lz"
@@ -536,7 +536,7 @@ MagnemiteBackpic:    INCBIN "gfx/pics/magnemite/back.2bpp.lz"
 ; 15bffa
 
 
-SECTION "Pics 16", ROMX, BANK[PICS_16]
+SECTION "Pics 16", ROMX
 
 HoothootBackpic:     INCBIN "gfx/pics/hoothoot/back.2bpp.lz"
 NoctowlBackpic:      INCBIN "gfx/pics/noctowl/back.2bpp.lz"
@@ -594,7 +594,7 @@ UnownHBackpic:       INCBIN "gfx/pics/unown_h/back.2bpp.lz"
 ; 15ffff
 
 
-SECTION "Pics 17", ROMX, BANK[PICS_17]
+SECTION "Pics 17", ROMX
 
 ParasBackpic:        INCBIN "gfx/pics/paras/back.2bpp.lz"
 VaporeonBackpic:     INCBIN "gfx/pics/vaporeon/back.2bpp.lz"
@@ -660,7 +660,7 @@ UnownDBackpic:       INCBIN "gfx/pics/unown_d/back.2bpp.lz"
 ; 163ffc
 
 
-SECTION "Pics 18", ROMX, BANK[PICS_18]
+SECTION "Pics 18", ROMX
 
 SpinarakBackpic:     INCBIN "gfx/pics/spinarak/back.2bpp.lz"
 RaikouBackpic:       INCBIN "gfx/pics/raikou/back.2bpp.lz"
@@ -725,7 +725,7 @@ UnownRBackpic:       INCBIN "gfx/pics/unown_r/back.2bpp.lz"
 ; 1669d3
 
 
-SECTION "Pics 19", ROMX, BANK[PICS_19]
+SECTION "Pics 19", ROMX
 
 ; Seems to be an accidental copy of the previous bank
 

--- a/home.asm
+++ b/home.asm
@@ -1,18 +1,18 @@
 INCLUDE "includes.asm"
 
-SECTION "NULL", ROM0[0]
+SECTION "NULL", ROM0
 NULL::
 
 INCLUDE "rst.asm"
 INCLUDE "interrupts.asm"
 
-SECTION "Header", ROM0[$100]
+SECTION "Header", ROM0
 
 Start::
 	nop
 	jp _Start
 
-SECTION "Home", ROM0[$150]
+SECTION "Home", ROM0
 
 INCLUDE "home/init.asm"
 INCLUDE "home/vblank.asm"

--- a/home.asm
+++ b/home.asm
@@ -133,7 +133,7 @@ INCLUDE "home/sram.asm"
 ; Register aliases
 
 _hl_:: ; 2fec
-	jp [hl]
+	jp hl
 ; 2fed
 
 _de_:: ; 2fed

--- a/home/farcall.asm
+++ b/home/farcall.asm
@@ -50,5 +50,5 @@ ReturnFarCall:: ; 2d6e
 ; 2d82
 
 FarJump_hl:: ; 2d82
-	jp [hl]
+	jp hl
 ; 2d83

--- a/home/menu.asm
+++ b/home/menu.asm
@@ -332,7 +332,7 @@ Function1eda:: ; 1eda
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 1eff
 
 Function1eff:: ; 1eff
@@ -454,7 +454,7 @@ MenuJumptable:: ; 1fa7
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 1fb1
 
 GetMenuDataPointerTableEntry:: ; 1fb1

--- a/home/text.asm
+++ b/home/text.asm
@@ -906,7 +906,7 @@ Text_START_ASM:: ; 14c9
 
 	bit 7, h
 	jr nz, .not_rom
-	jp [hl]
+	jp hl
 
 .not_rom
 	ld a, "@"

--- a/items/item_effects.asm
+++ b/items/item_effects.asm
@@ -273,7 +273,7 @@ endr
 	ld l, a
 	ld de, .skip_or_return_from_ball_fn
 	push de
-	jp [hl]
+	jp hl
 
 .skip_or_return_from_ball_fn
 	ld a, [CurItem]

--- a/macros.asm
+++ b/macros.asm
@@ -93,7 +93,7 @@ dab: MACRO ; dwb address, bank
 	ENDM
 
 lb: MACRO ; r, hi, lo
-	ld \1, (\2 & $ff) << 8 + (\3 & $ff)
+	ld \1, ((\2) & $ff) << 8 + ((\3) & $ff)
 	ENDM
 
 ln: MACRO ; r, hi, lo
@@ -268,5 +268,5 @@ jumptable: MACRO
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 endm

--- a/macros/move_anim.asm
+++ b/macros/move_anim.asm
@@ -11,7 +11,7 @@ endc
 anim_obj: macro
 	db anim_obj_command
 	db \1 ; obj
-	db (\2 << 3) + \3 ; x
+	db (\2 * 8) + \3 ; x
 	db (\4 << 3) + \5 ; y
 	db \6 ; param
 	endm

--- a/main.asm
+++ b/main.asm
@@ -1,6 +1,6 @@
 INCLUDE "includes.asm"
 
-SECTION "bank1", ROMX, BANK[$1]
+SECTION "bank1", ROMX
 
 PlaceWaitingText:: ; 4000
 	hlcoord 3, 10
@@ -715,7 +715,7 @@ Predef1: ; 747a
 ; not used
 	ret
 
-SECTION "bank2", ROMX, BANK[$2]
+SECTION "bank2", ROMX
 
 BlankScreen: ; 8000
 	call DisableSpriteUpdates
@@ -1629,7 +1629,7 @@ INCLUDE "engine/predef.asm"
 
 INCLUDE "engine/color.asm"
 
-SECTION "bank3", ROMX, BANK[$3]
+SECTION "bank3", ROMX
 
 CheckTime:: ; c000
 	ld a, [TimeOfDay]
@@ -5096,7 +5096,7 @@ KnowsMove: ; f9ea
 	text_jump UnknownText_0x1c5ea8
 	db "@"
 
-SECTION "bank4", ROMX, BANK[$4]
+SECTION "bank4", ROMX
 
 INCLUDE "engine/pack.asm"
 INCLUDE "engine/time.asm"
@@ -5320,7 +5320,7 @@ root	set 1
 root	set root+1
 	endr
 
-SECTION "bank5", ROMX, BANK[$5]
+SECTION "bank5", ROMX
 
 INCLUDE "engine/rtc.asm"
 INCLUDE "engine/overworld.asm"
@@ -5337,27 +5337,27 @@ INCLUDE "event/daycare.asm"
 INCLUDE "event/photo.asm"
 INCLUDE "engine/breeding/egg.asm"
 
-SECTION "Tileset Data 1", ROMX, BANK[TILESETS_1]
+SECTION "Tileset Data 1", ROMX
 
 INCLUDE "tilesets/data_1.asm"
 
-SECTION "Roofs", ROMX, BANK[ROOFS]
+SECTION "Roofs", ROMX
 
 INCLUDE "tilesets/roofs.asm"
 
-SECTION "Tileset Data 2", ROMX, BANK[TILESETS_2]
+SECTION "Tileset Data 2", ROMX
 
 INCLUDE "tilesets/data_2.asm"
 
-SECTION "bank8", ROMX, BANK[$8]
+SECTION "bank8", ROMX
 
 INCLUDE "engine/clock_reset.asm"
 
-SECTION "Tileset Data 3", ROMX, BANK[TILESETS_3]
+SECTION "Tileset Data 3", ROMX
 
 INCLUDE "tilesets/data_3.asm"
 
-SECTION "bank9", ROMX, BANK[$9]
+SECTION "bank9", ROMX
 
 StringBufferPointers:: ; 24000
 	dw StringBuffer3
@@ -5876,7 +5876,7 @@ Kurt_SelectQuantity_InterpretJoypad: ; 27a28
 	ld b, a
 	ret
 
-SECTION "bankA", ROMX, BANK[$A]
+SECTION "bankA", ROMX
 
 INCLUDE "engine/link.asm"
 
@@ -6062,7 +6062,7 @@ INCBIN "gfx/misc/player.6x6.2bpp.lz"
 DudeBackpic: ; 2bbaa
 INCBIN "gfx/misc/dude.6x6.2bpp.lz"
 
-SECTION "bankB", ROMX, BANK[$B]
+SECTION "bankB", ROMX
 
 INCLUDE "battle/trainer_huds.asm"
 
@@ -6496,15 +6496,15 @@ PlaceGraphic: ; 2ef6e
 	jr nz, .x2
 	ret
 
-SECTION "Tileset Data 4", ROMX, BANK[TILESETS_4]
+SECTION "Tileset Data 4", ROMX
 
 INCLUDE "tilesets/data_4.asm"
 
-SECTION "Effect Commands", ROMX, BANK[$D]
+SECTION "Effect Commands", ROMX
 
 INCLUDE "battle/effect_commands.asm"
 
-SECTION "Enemy Trainers", ROMX, BANK[$E]
+SECTION "Enemy Trainers", ROMX
 
 INCLUDE "battle/ai/items.asm"
 
@@ -6584,19 +6584,19 @@ INCLUDE "trainers/trainer_pointers.asm"
 
 INCLUDE "trainers/trainers.asm"
 
-SECTION "Battle Core", ROMX, BANK[$F]
+SECTION "Battle Core", ROMX
 
 INCLUDE "battle/core.asm"
 
 INCLUDE "battle/effect_command_pointers.asm"
 
-SECTION "bank10", ROMX, BANK[$10]
+SECTION "bank10", ROMX
 
 INCLUDE "engine/pokedex.asm"
 
 INCLUDE "engine/evolve.asm"
 
-SECTION "bank11", ROMX, BANK[$11]
+SECTION "bank11", ROMX
 
 INCLUDE "engine/fruit_trees.asm"
 
@@ -6894,7 +6894,7 @@ INCLUDE "data/pokedex/entry_pointers.asm"
 
 INCLUDE "engine/mail.asm"
 
-SECTION "Crystal Unique", ROMX, BANK[$12]
+SECTION "Crystal Unique", ROMX
 
 INCLUDE "engine/init_gender.asm"
 
@@ -7108,7 +7108,7 @@ Buena_ExitMenu: ; 4ae5e
 	ld [hOAMUpdate], a
 	ret
 
-SECTION "bank13", ROMX, BANK[$13]
+SECTION "bank13", ROMX
 
 SwapTextboxPalettes:: ; 4c000
 	hlcoord 0, 0
@@ -8926,7 +8926,7 @@ INCLUDE "misc/gbc_only.asm"
 
 INCLUDE "event/poke_seer.asm"
 
-SECTION "bank14", ROMX, BANK[$14]
+SECTION "bank14", ROMX
 
 INCLUDE "engine/party_menu.asm"
 INCLUDE "event/poisonstep.asm"
@@ -10195,11 +10195,11 @@ UnknownEggPic:: ; 53d9c
 ; Another egg pic. This is shifted up a few pixels.
 INCBIN "gfx/misc/unknown_egg.5x5.2bpp.lz"
 
-SECTION "bank19", ROMX, BANK[$19]
+SECTION "bank19", ROMX
 
 INCLUDE "text/phone/extra.asm"
 
-SECTION "bank20", ROMX, BANK[$20]
+SECTION "bank20", ROMX
 
 INCLUDE "engine/player_movement.asm"
 
@@ -10212,7 +10212,7 @@ INCLUDE "text/battle.asm"
 
 INCLUDE "engine/debug.asm"
 
-SECTION "bank21", ROMX, BANK[$21]
+SECTION "bank21", ROMX
 
 INCLUDE "engine/printer.asm"
 
@@ -10220,7 +10220,7 @@ INCLUDE "battle/anim_gfx.asm"
 
 INCLUDE "event/halloffame.asm"
 
-SECTION "bank22", ROMX, BANK[$22]
+SECTION "bank22", ROMX
 
 INCLUDE "event/kurt.asm"
 
@@ -10497,7 +10497,7 @@ INCLUDE "event/dratini.asm"
 INCLUDE "event/battle_tower.asm"
 INCLUDE "misc/mobile_22_2.asm"
 
-SECTION "bank23", ROMX, BANK[$23]
+SECTION "bank23", ROMX
 
 Predef35: ; 8c000
 Predef36:
@@ -10525,7 +10525,7 @@ INCLUDE "engine/sprites.asm"
 
 INCLUDE "engine/mon_icons.asm"
 
-SECTION "bank24", ROMX, BANK[$24]
+SECTION "bank24", ROMX
 
 INCLUDE "engine/phone.asm"
 INCLUDE "engine/timeset.asm"
@@ -10534,12 +10534,12 @@ INCLUDE "engine/pokegear.asm"
 INCLUDE "engine/fish.asm"
 INCLUDE "engine/slot_machine.asm"
 
-SECTION "Phone Engine", ROMX, BANK[$28]
+SECTION "Phone Engine", ROMX
 
 INCLUDE "engine/more_phone_scripts.asm"
 INCLUDE "engine/buena_phone_scripts.asm"
 
-SECTION "Phone Text", ROMX, BANK[$29]
+SECTION "Phone Text", ROMX
 
 INCLUDE "text/phone/anthony_overworld.asm"
 INCLUDE "text/phone/todd_overworld.asm"
@@ -10559,11 +10559,11 @@ INCLUDE "text/phone/kenji_overworld.asm"
 INCLUDE "text/phone/parry_overworld.asm"
 INCLUDE "text/phone/erin_overworld.asm"
 
-SECTION "Tileset Data 5", ROMX, BANK[TILESETS_5]
+SECTION "Tileset Data 5", ROMX
 
 INCLUDE "tilesets/data_5.asm"
 
-SECTION "bank2E", ROMX, BANK[$2E]
+SECTION "bank2E", ROMX
 
 INCLUDE "engine/events_3.asm"
 
@@ -10571,7 +10571,7 @@ INCLUDE "engine/radio.asm"
 
 INCLUDE "gfx/mail.asm"
 
-SECTION "bank2F", ROMX, BANK[$2F]
+SECTION "bank2F", ROMX
 
 INCLUDE "engine/std_scripts.asm"
 
@@ -10609,15 +10609,15 @@ StartBattleWithMapTrainerScript: ; 0xbe68a
 AlreadyBeatenTrainerScript:
 	scripttalkafter
 
-SECTION "bank30", ROMX, BANK[$30]
+SECTION "bank30", ROMX
 
 INCLUDE "gfx/overworld/sprites_1.asm"
 
-SECTION "bank31", ROMX, BANK[$31]
+SECTION "bank31", ROMX
 
 INCLUDE "gfx/overworld/sprites_2.asm"
 
-SECTION "bank32", ROMX, BANK[$32]
+SECTION "bank32", ROMX
 
 INCLUDE "battle/bg_effects.asm"
 
@@ -10675,7 +10675,7 @@ LoadPoisonBGPals: ; cbcdd
 TheEndGFX:: ; cbd2e
 INCBIN "gfx/credits/theend.2bpp"
 
-SECTION "bank33", ROMX, BANK[$33]
+SECTION "bank33", ROMX
 
 DisplayCaughtContestMonStats: ; cc000
 
@@ -10790,7 +10790,7 @@ INCLUDE "battle/anim_commands.asm"
 
 INCLUDE "battle/anim_objects.asm"
 
-SECTION "Pic Animations 1", ROMX, BANK[$34]
+SECTION "Pic Animations 1", ROMX
 
 INCLUDE "gfx/pics/animation.asm"
 
@@ -10830,26 +10830,26 @@ INCLUDE "gfx/pics/bitmasks.asm"
 INCLUDE "gfx/pics/unown_bitmask_pointers.asm"
 INCLUDE "gfx/pics/unown_bitmasks.asm"
 
-SECTION "Pic Animations 2", ROMX, BANK[$35]
+SECTION "Pic Animations 2", ROMX
 
 INCLUDE "gfx/pics/frame_pointers.asm"
 INCLUDE "gfx/pics/kanto_frames.asm"
 
-SECTION "bank36", ROMX, BANK[$36]
+SECTION "bank36", ROMX
 
 FontInversed: INCBIN "gfx/misc/font_inversed.1bpp"
 
-SECTION "Pic Animations 3", ROMX, BANK[$36]
+SECTION "Pic Animations 3", ROMX
 
 INCLUDE "gfx/pics/johto_frames.asm"
 INCLUDE "gfx/pics/unown_frame_pointers.asm"
 INCLUDE "gfx/pics/unown_frames.asm"
 
-SECTION "Tileset Data 6", ROMX, BANK[TILESETS_6]
+SECTION "Tileset Data 6", ROMX
 
 INCLUDE "tilesets/data_6.asm"
 
-SECTION "bank38", ROMX, BANK[$38]
+SECTION "bank38", ROMX
 
 Functione0000: ; e0000
 ; something to do with Unown printer
@@ -10977,7 +10977,7 @@ INCLUDE "engine/unown_puzzle.asm"
 INCLUDE "engine/dummy_game.asm"
 INCLUDE "engine/billspc.asm"
 
-SECTION "bank39", ROMX, BANK[$39]
+SECTION "bank39", ROMX
 
 CopyrightGFX:: ; e4000
 INCBIN "gfx/misc/copyright.2bpp"
@@ -10985,7 +10985,7 @@ INCBIN "gfx/misc/copyright.2bpp"
 INCLUDE "engine/options_menu.asm"
 INCLUDE "engine/crystal_intro.asm"
 
-SECTION "bank3E", ROMX, BANK[$3E]
+SECTION "bank3E", ROMX
 
 INCLUDE "gfx/font.asm"
 INCLUDE "engine/time_capsule/conversion.asm"
@@ -10996,7 +10996,7 @@ INCLUDE "battle/hidden_power.asm"
 
 INCLUDE "battle/misc.asm"
 
-SECTION "bank3F", ROMX, BANK[$3F]
+SECTION "bank3F", ROMX
 
 INCLUDE "tilesets/animations.asm"
 
@@ -11004,11 +11004,11 @@ INCLUDE "engine/npctrade.asm"
 
 INCLUDE "event/mom_phone.asm"
 
-SECTION "bank40", ROMX, BANK[$40]
+SECTION "bank40", ROMX
 
 INCLUDE "misc/mobile_40.asm"
 
-SECTION "bank41", ROMX, BANK[$41]
+SECTION "bank41", ROMX
 
 INCLUDE "misc/gfx_41.asm"
 
@@ -11020,11 +11020,11 @@ INCLUDE "battle/used_move_text.asm"
 
 INCLUDE "misc/mobile_41.asm"
 
-SECTION "bank42", ROMX, BANK[$42]
+SECTION "bank42", ROMX
 
 INCLUDE "misc/mobile_42.asm"
 
-SECTION "Intro Logo", ROMX, BANK[$42]
+SECTION "Intro Logo", ROMX
 
 IntroLogoGFX: ; 109407
 INCBIN "gfx/intro/logo.2bpp.lz"
@@ -11036,24 +11036,24 @@ INCLUDE "engine/title.asm"
 INCLUDE "misc/mobile_45.asm"
 INCLUDE "misc/mobile_46.asm"
 
-SECTION "bank47", ROMX, BANK[$47]
+SECTION "bank47", ROMX
 
 INCLUDE "misc/battle_tower_47.asm"
 
-SECTION "bank5B", ROMX, BANK[$5B]
+SECTION "bank5B", ROMX
 
 INCLUDE "misc/mobile_5b.asm"
 INCLUDE "engine/link_trade.asm"
 
-SECTION "bank5C", ROMX, BANK[$5C]
+SECTION "bank5C", ROMX
 
 INCLUDE "misc/mobile_5c.asm"
 
-SECTION "bank5D", ROMX, BANK[$5D]
+SECTION "bank5D", ROMX
 
 INCLUDE "text/phone/extra3.asm"
 
-SECTION "bank5E", ROMX, BANK[$5E]
+SECTION "bank5E", ROMX
 
 _UpdateBattleHUDs:
 	callba DrawPlayerHUD
@@ -11067,7 +11067,7 @@ _UpdateBattleHUDs:
 
 INCLUDE "misc/mobile_5f.asm"
 
-SECTION "Common Text 1", ROMX, BANK[$6C]
+SECTION "Common Text 1", ROMX
 
 INCLUDE "text/stdtext.asm"
 INCLUDE "text/phone/jack_overworld.asm"
@@ -11082,14 +11082,14 @@ INCLUDE "text/phone/wade_overworld.asm"
 INCLUDE "text/phone/ralph_overworld.asm"
 INCLUDE "text/phone/liz_overworld.asm"
 
-SECTION "bank6D", ROMX, BANK[$6D]
+SECTION "bank6D", ROMX
 
 INCLUDE "text/phone/mom.asm"
 INCLUDE "text/phone/bill.asm"
 INCLUDE "text/phone/elm.asm"
 INCLUDE "text/phone/trainers1.asm"
 
-SECTION "bank72", ROMX, BANK[$72]
+SECTION "bank72", ROMX
 
 ItemNames::
 INCLUDE "items/item_names.asm"
@@ -11101,7 +11101,7 @@ INCLUDE "battle/move_names.asm"
 
 INCLUDE "engine/landmarks.asm"
 
-SECTION "bank77", ROMX, BANK[$77]
+SECTION "bank77", ROMX
 
 UnownFont: ; 1dc000
 INCBIN "gfx/misc/unown_font.2bpp"
@@ -11114,11 +11114,11 @@ INCBIN "gfx/mobile/hp.1bpp"
 MobileLvIcon: ; 1dc599
 INCBIN "gfx/mobile/lv.1bpp"
 
-SECTION "Tileset Data 7", ROMX, BANK[TILESETS_7]
+SECTION "Tileset Data 7", ROMX
 
 INCLUDE "tilesets/data_7.asm"
 
-SECTION "bank77_2", ROMX, BANK[$77]
+SECTION "bank77_2", ROMX
 
 Function1dd6a9: ; 1dd6a9
 	ld a, b
@@ -11547,19 +11547,19 @@ LeggiPostaInglese:
 	jr nz, .loop
 	ret
 
-SECTION "Tileset Data 8", ROMX, BANK[TILESETS_8]
+SECTION "Tileset Data 8", ROMX
 
 INCLUDE "tilesets/data_8.asm"
 
-SECTION "bank7B", ROMX, BANK[$7B]
+SECTION "bank7B", ROMX
 
 INCLUDE "text/battle_tower.asm"
 
-SECTION "bank7C", ROMX, BANK[$7C]
+SECTION "bank7C", ROMX
 
 INCLUDE "data/battle_tower_2.asm"
 
-SECTION "bank7D", ROMX, BANK[$7D]
+SECTION "bank7D", ROMX
 
 	db $cc, $6b, $1e ; XXX
 
@@ -11602,14 +11602,14 @@ Function1f5d9f: ; 1f5d9f
 Unknown_1f5db4:
 INCBIN "unknown/1f5db4.bin"
 
-SECTION "bank7E", ROMX, BANK[$7E]
+SECTION "bank7E", ROMX
 
 INCLUDE "data/battle_tower.asm"
 INCLUDE "data/odd_eggs.asm"
 
-SECTION "bank7F", ROMX, BANK[$7F]
+SECTION "bank7F", ROMX
 
-SECTION "stadium2", ROMX[$8000-$220], BANK[$7F]
+SECTION "stadium2", ROMX
 
 IF DEF(CRYSTAL11)
 INCBIN "misc/stadium2_2.bin"

--- a/main.asm
+++ b/main.asm
@@ -6728,7 +6728,7 @@ DisplayDexEntry: ; 4424d
 	jr z, .skip_height
 	push hl
 	push de
-	ld hl, [sp+$0]
+	ld hl, sp+$0
 	ld d, h
 	ld e, l
 	hlcoord 12, 7
@@ -6752,7 +6752,7 @@ DisplayDexEntry: ; 4424d
 	or d
 	jr z, .skip_weight
 	push de
-	ld hl, [sp+$0]
+	ld hl, sp+$0
 	ld d, h
 	ld e, l
 	hlcoord 11, 9
@@ -8602,7 +8602,7 @@ CatchTutorial:: ; 4e554
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .dw: ; 4e564 (13:6564)
 	dw .DudeTutorial
@@ -11126,7 +11126,7 @@ Function1dd6a9: ; 1dd6a9
 	ld c, a
 	push bc
 	push de
-	ld hl, [sp+$2]
+	ld hl, sp+$2
 	ld d, h
 	ld e, l
 	pop hl
@@ -11152,7 +11152,7 @@ PrintHoursMins ; 1dd6bb (77:56bb)
 	ld b, a
 ; Crazy stuff happening with the stack
 	push bc
-	ld hl, [sp+$1]
+	ld hl, sp+$1
 	push de
 	push hl
 	pop de
@@ -11164,7 +11164,7 @@ PrintHoursMins ; 1dd6bb (77:56bb)
 	inc hl
 	ld d, h
 	ld e, l
-	ld hl, [sp+$0]
+	ld hl, sp+$0
 	push de
 	push hl
 	pop de

--- a/misc/battle_tower_5c.asm
+++ b/misc/battle_tower_5c.asm
@@ -223,7 +223,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 170249
 
 .dw: ; 170249
@@ -696,7 +696,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 17051f
 
 .dw: ; 17051f
@@ -953,7 +953,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 170696
 
 
@@ -1451,7 +1451,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .invalid
 	ld a, $5

--- a/misc/fixed_words.asm
+++ b/misc/fixed_words.asm
@@ -2507,7 +2507,7 @@ Function11d0b6: ; 11d0b6 (47:50b6)
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable
 	dw .zero

--- a/misc/gfx_41.asm
+++ b/misc/gfx_41.asm
@@ -229,7 +229,7 @@ CallInSafeGFXMode: ; 104177
 ; 10419c
 
 ._hl_: ; 10419c
-	jp [hl]
+	jp hl
 ; 10419d
 
 

--- a/misc/mobile_42.asm
+++ b/misc/mobile_42.asm
@@ -378,7 +378,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 10828a
 
 .Jumptable: ; 10828a

--- a/misc/mobile_45.asm
+++ b/misc/mobile_45.asm
@@ -146,7 +146,7 @@ Function114243:: ; 114243
 	ld h, [hl]
 	ld l, a
 	pop de
-	jp [hl]
+	jp hl
 
 ; 11425c
 
@@ -5412,7 +5412,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; 1165af
 
@@ -6947,7 +6947,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 Jumptable_117728: ; 117728 (45:7728)
 	dw Function117738
@@ -7436,7 +7436,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable: ; 0x117af8
 	dw Function117b06

--- a/misc/mobile_45_sprite_engine.asm
+++ b/misc/mobile_45_sprite_engine.asm
@@ -381,7 +381,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; 1161c7
 

--- a/misc/mobile_46.asm
+++ b/misc/mobile_46.asm
@@ -5874,7 +5874,7 @@ Function11ad6e: ; 11ad6e
 	ld a, [wJumptableIndex]
 	ld hl, Jumptable_11ad78
 	call Function11b239
-	jp [hl]
+	jp hl
 ; 11ad78
 
 Jumptable_11ad78: ; 11ad78

--- a/misc/mobile_5c.asm
+++ b/misc/mobile_5c.asm
@@ -376,7 +376,7 @@ endr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 Jumptable_171a45: ; 171a45 (5c:5a45)
 	dw Function171a95

--- a/misc/mobile_5f.asm
+++ b/misc/mobile_5f.asm
@@ -1146,7 +1146,7 @@ Function17d711:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 asm_17d721
 	call Function17e5af
@@ -3746,7 +3746,7 @@ Function17f047: ; 17f047
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .asm_17f05f
 	scf

--- a/predef/cgb.asm
+++ b/predef/cgb.asm
@@ -25,7 +25,7 @@ Predef_LoadSGBLayoutCGB: ; 8d59
 	ld l, a
 	ld de, .ReturnFromJumpTable
 	push de
-	jp [hl]
+	jp hl
 ; 8d79
 
 .ReturnFromJumpTable: ; 8d79
@@ -491,7 +491,7 @@ _CGB07: ; 9122
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 ; 912d
 
 Jumptable_912d: ; 912d

--- a/predef/crystal.asm
+++ b/predef/crystal.asm
@@ -17,7 +17,7 @@ GetMysteryGift_MobileAdapterLayout: ; 4930f (mobile)
 	ld l, a
 	ld de, .done
 	push de
-	jp [hl]
+	jp hl
 .done
 	ret
 ; 49330 (12:5330)

--- a/predef/sgb.asm
+++ b/predef/sgb.asm
@@ -20,7 +20,7 @@ Predef_LoadSGBLayout: ; 864c
 	ld l, a
 	ld de, .Finish
 	push de
-	jp [hl]
+	jp hl
 ; 866f
 
 .Jumptable: ; 866f

--- a/rst.asm
+++ b/rst.asm
@@ -29,7 +29,7 @@ endr
 	ld h, [hl]
 	ld l, a
 	pop de
-	jp [hl]
+	jp hl
 
 ; SECTION "rst30",ROM0[$30]
 ; rst30 is midst rst28

--- a/rst.asm
+++ b/rst.asm
@@ -1,24 +1,24 @@
 ; rst vectors
 
-SECTION "rst0",ROM0[0]
+SECTION "rst0", ROM0
 	di
 	jp Start
 
-SECTION "rst8",ROM0[FarCall]
+SECTION "rst8", ROM0
 	jp FarCall_hl
 
-SECTION "rst10",ROM0[Bankswitch]
+SECTION "rst10", ROM0
 	ld [hROMBank], a
 	ld [MBC3RomBank], a
 	ret
 
-SECTION "rst18",ROM0[$18]
+SECTION "rst18", ROM0
 	rst $38
 
-SECTION "rst20",ROM0[$20]
+SECTION "rst20", ROM0
 	rst $38
 
-SECTION "rst28",ROM0[JumpTable]
+SECTION "rst28", ROM0
 	push de
 	ld e, a
 	ld d, 0
@@ -34,5 +34,5 @@ endr
 ; SECTION "rst30",ROM0[$30]
 ; rst30 is midst rst28
 
-SECTION "rst38",ROM0[$38]
+SECTION "rst38", ROM0
 	rst $38

--- a/sram.asm
+++ b/sram.asm
@@ -196,7 +196,7 @@ sCrystalData::
 	ds wCrystalDataEnd - wCrystalData
 sMobileEventIndexBackup:: ds 1
 
-SECTION "SRAM Battle Tower", SRAM, BANK [1]
+SECTION "SRAM Battle Tower", SRAM [$be45], BANK [1]
 ; data of the BattleTower must be in SRAM because you can save and leave between battles
 sBattleTowerChallengeState:: ds 1
 ; 0: normal

--- a/sram.asm
+++ b/sram.asm
@@ -3,11 +3,11 @@ SRAM_End   EQU $c000
 GLOBAL SRAM_Begin, SRAM_End
 
 
-SECTION "Scratch", SRAM, BANK [0]
+SECTION "Scratch", SRAM
 sScratch::
 
 
-SECTION "SRAM Bank 0", SRAM [$a600], BANK [0]
+SECTION "SRAM Bank 0", SRAM
 
 ; a600
 sPartyMail::
@@ -78,7 +78,7 @@ sRTCStatusFlags:: ds 8
 sLuckyNumberDay:: ds 1
 sLuckyIDNumber:: ds 2
 
-SECTION "Backup Save", SRAM [$b200], BANK [0]
+SECTION "Backup Save", SRAM
 sBackupOptions:: ds OptionsEnd - Options
 
 s0_b208:: ds 1
@@ -98,7 +98,7 @@ s0_bf0f:: ds 1
 sStackTop:: ds 2
 
 
-SECTION "SRAM Bank 1", SRAM, BANK [1]
+SECTION "SRAM Bank 1", SRAM
 
 sOptions:: ds OptionsEnd - Options
 
@@ -196,7 +196,7 @@ sCrystalData::
 	ds wCrystalDataEnd - wCrystalData
 sMobileEventIndexBackup:: ds 1
 
-SECTION "SRAM Battle Tower", SRAM [$be45], BANK [1]
+SECTION "SRAM Battle Tower", SRAM
 ; data of the BattleTower must be in SRAM because you can save and leave between battles
 sBattleTowerChallengeState:: ds 1
 ; 0: normal
@@ -221,7 +221,7 @@ sBTPkmnPrevPrevTrainer1:: ds 1
 sBTPkmnPrevPrevTrainer2:: ds 1
 sBTPkmnPrevPrevTrainer3:: ds 1
 
-SECTION "SRAM Speedchoice Stats", SRAM, BANK [1]
+SECTION "SRAM Speedchoice Stats", SRAM
 sStatsStart::
 sStatsFrameCount:: ds 4
 sStatsOWFrameCount:: ds 4
@@ -276,7 +276,7 @@ sStatsNumPokemaniacsFought:: dw
 sStatsEnd::
 
 
-SECTION "Boxes 1-7",  SRAM, BANK [2]
+SECTION "Boxes 1-7",  SRAM
 	box sBox1
 	box sBox2
 	box sBox3
@@ -285,7 +285,7 @@ SECTION "Boxes 1-7",  SRAM, BANK [2]
 	box sBox6
 	box sBox7
 
-SECTION "Boxes 8-14", SRAM, BANK [3]
+SECTION "Boxes 8-14", SRAM
 	box sBox8
 	box sBox9
 	box sBox10

--- a/tilesets/animations.asm
+++ b/tilesets/animations.asm
@@ -33,7 +33,7 @@ endr
 	ld h, [hl]
 	ld l, a
 
-	jp [hl]
+	jp hl
 ; fc01b
 
 Tileset00Anim: ; 0xfc01b
@@ -421,7 +421,7 @@ ScrollTileDown: ; fc36a
 
 
 AnimateFountain: ; fc387
-	ld hl, [sp+0]
+	ld hl, sp+0
 	ld b, h
 	ld c, l
 	ld hl, .frames
@@ -463,7 +463,7 @@ AnimateWaterTile: ; fc402
 ; Draw a water tile for the current frame in VRAM tile at de.
 
 ; Save sp in bc (see WriteTile).
-	ld hl, [sp+0]
+	ld hl, sp+0
 	ld b, h
 	ld c, l
 	
@@ -498,7 +498,7 @@ WaterTileFrames: ; fc41c
 
 
 ForestTreeLeftAnimation: ; fc45c
-	ld hl, [sp+0]
+	ld hl, sp+0
 	ld b, h
 	ld c, l
 
@@ -540,7 +540,7 @@ ForestTreeRightFrames: ; fc4a4
 
 
 ForestTreeRightAnimation: ; fc4c4
-	ld hl, [sp+0]
+	ld hl, sp+0
 	ld b, h
 	ld c, l
 
@@ -575,7 +575,7 @@ endr
 
 
 ForestTreeLeftAnimation2: ; fc4f2
-	ld hl, [sp+0]
+	ld hl, sp+0
 	ld b, h
 	ld c, l
 
@@ -607,7 +607,7 @@ endr
 
 
 ForestTreeRightAnimation2: ; fc51c
-	ld hl, [sp+0]
+	ld hl, sp+0
 	ld b, h
 	ld c, l
 
@@ -672,7 +672,7 @@ AnimateFlowerTile: ; fc56d
 ; No parameters.
 
 ; Save sp in bc (see WriteTile).
-	ld hl, [sp+0]
+	ld hl, sp+0
 	ld b, h
 	ld c, l
 	
@@ -708,7 +708,7 @@ FlowerTileFrames: ; fc58c
 
 SafariFountainAnim1: ; fc5cc
 ; Splash in the bottom-right corner of the fountain.
-	ld hl, [sp+0]
+	ld hl, sp+0
 	ld b, h
 	ld c, l
 	ld a, [TileAnimationTimer]
@@ -731,7 +731,7 @@ endr
 
 SafariFountainAnim2: ; fc5eb
 ; Splash in the top-left corner of the fountain.
-	ld hl, [sp+0]
+	ld hl, sp+0
 	ld b, h
 	ld c, l
 	ld a, [TileAnimationTimer]
@@ -762,7 +762,7 @@ AnimateSproutPillarTile: ; fc645
 ; 	Destination (VRAM)
 ;	Address of the first tile in the frame array
 
-	ld hl, [sp+0]
+	ld hl, sp+0
 	ld b, h
 	ld c, l
 
@@ -822,7 +822,7 @@ AnimateWhirlpoolTile: ; fc678
 ; Only does one of 4 tiles at a time.
 
 ; Save sp in bc (see WriteTile).
-	ld hl, [sp+0]
+	ld hl, sp+0
 	ld b, h
 	ld c, l
 	
@@ -862,7 +862,7 @@ WriteTileFromBuffer: ; fc696
 ; Write tiledata at wTileAnimBuffer to de.
 ; wTileAnimBuffer is loaded to sp for WriteTile.
 
-	ld hl, [sp+0]
+	ld hl, sp+0
 	ld b, h
 	ld c, l
 	
@@ -879,7 +879,7 @@ WriteTileToBuffer: ; fc6a2
 ; Write tiledata de to wTileAnimBuffer.
 ; de is loaded to sp for WriteTile.
 
-	ld hl, [sp+0]
+	ld hl, sp+0
 	ld b, h
 	ld c, l
 	

--- a/trainers/read_party.asm
+++ b/trainers/read_party.asm
@@ -70,7 +70,7 @@ endr
 	ld l, a
 	ld bc, .done
 	push bc
-	jp [hl]
+	jp hl
 
 .done
 	jp ComputeTrainerReward

--- a/wram.asm
+++ b/wram.asm
@@ -2,7 +2,7 @@ INCLUDE "includes.asm"
 INCLUDE "macros/wram.asm"
 INCLUDE "vram.asm"
 
-SECTION "Stack", WRAM0
+SECTION "Stack", WRAM0 [$c000]
 wc000::
 StackBottom::
 	ds $100 - 1
@@ -11,7 +11,7 @@ StackTop::
 	ds 1
 
 
-SECTION "Audio", WRAM0
+SECTION "AudioWRAM", WRAM0 [$c100]
 wMusic::
 MusicPlaying:: ; c100
 ; nonzero if playing
@@ -134,7 +134,7 @@ wMapMusic:: ; c2c0
 wDontPlayMapMusicOnReload:: ds 1
 wMusicEnd::
 
-SECTION "WRAM", WRAM0
+SECTION "WRAM", WRAM0 [$c2c2]
 
 wLZAddress:: dw ; c2c2
 wLZBank::    db ; c2c4
@@ -220,8 +220,9 @@ SECTION "wSpriteAnims", WRAM0 [$c300]
 ; wc300 - wc313 is a 10x2 dictionary.
 ; keys: taken from third column of SpriteAnimSeqData
 ; values: VTiles
+UNION
 wSpriteAnimDict:: ds 10 * 2
-	ds wSpriteAnimDict - @
+NEXTU
 wc300:: ds 1
 wc301:: ds 1
 wc302:: ds 1
@@ -241,6 +242,7 @@ wc310:: ds 1
 wc311:: ds 1
 wc312:: ds 1
 wc313:: ds 1
+ENDU
 wSpriteAnimationStructs::
 
 sprite_anim_struct: MACRO
@@ -282,11 +284,15 @@ wc384::
 SpriteAnim8:: sprite_anim_struct SpriteAnim8
 wc394::
 SpriteAnim9:: sprite_anim_struct SpriteAnim9
+
+UNION ; could be moved before anim structs, add a lot of empty ds
 wc3a4::
 SpriteAnim10:: sprite_anim_struct SpriteAnim10
 wSpriteAnimationStructsEnd::
-	ds -8
+NEXTU
+	ds 8
 wc3ac:: ds 8 ; c3ac
+ENDU
 wSpriteAnimCount:: ds 1
 wCurrSpriteOAMAddr:: ds 1
 
@@ -350,7 +356,7 @@ Sprites:: ; c400
 SpritesEnd::
 
 
-SECTION "Tilemap", WRAM0
+SECTION "Tilemap", WRAM0 [$c4a0]
 
 TileMap:: ; c4a0
 ; 20x18 grid of 8x8 tiles
@@ -358,19 +364,23 @@ TileMap:: ; c4a0
 TileMapEnd::
 
 
-SECTION "Battle", WRAM0
+SECTION "Battle", WRAM0 [$c608]
+UNION
 wc608::
 wOddEgg:: party_struct OddEgg
 wOddEggName:: ds PKMN_NAME_LENGTH
 wOddEggOTName:: ds PKMN_NAME_LENGTH
-	ds wc608 - @
-
+TEST3::
+NEXTU
 wBT_OTTemp:: battle_tower_struct wBT_OTTemp
-	ds wc608 - @
-
+TEST2:: ;SOMETHING HERE IS FUCKY
+; FIND OUT WHY THIS IS BIGGER THAN EXPECTED
+; THEN remove the [blahblahs] I added, and fix overworld
+; TODO TODO TODO probably redo battle tbh
+NEXTU
 	hall_of_fame wHallOfFameTemp
-	ds wc608 - @
-
+TEST1::
+NEXTU
 wMisc:: ; ds (SCREEN_WIDTH + 4) * (SCREEN_HEIGHT + 2)
 	ds 10
 wc612::
@@ -378,7 +388,7 @@ wc612::
 wInitHourBuffer:: ; c61c
 	ds 10
 wc626::
-	ds wc608 - @
+NEXTU
 
 wBattle::
 wEnemyMoveStruct::  move_struct wEnemyMoveStruct ; c608
@@ -571,6 +581,7 @@ PlayerSpdLevel:: ; c6ce
 PlayerSAtkLevel:: ; c6cf
 	ds 1
 
+UNION
 wc6d0::
 PlayerSDefLevel:: ; c6d0
 	ds 1
@@ -755,7 +766,7 @@ wBattleEnd::
 ; Battle RAM
 
 ; c741
-	ds wc6d0 - @
+NEXTU
 wTrademons::
 wPlayerTrademon:: trademon wPlayerTrademon
 wOTTrademon::     trademon wOTTrademon
@@ -771,7 +782,7 @@ wc7b9:: ds 1
 wc7ba:: ds 1
 wc7bb:: ds 2
 wc7bd::
-	ds wc6d0 - @
+NEXTU
 
 ; naming screen
 wNamingScreenDestinationPointer:: ds 2 ; c6d0
@@ -781,7 +792,7 @@ wNamingScreenType:: ds 1 ; c6d4
 wNamingScreenCursorObjectPointer:: ds 2 ; c6d5
 wNamingScreenLastCharacter:: ds 1 ; c6d7
 wNamingScreenStringEntryCoord:: ds 2 ; c6d8
-	ds wc6d0 - @
+NEXTU
 
 ; pokegear
 wPokegearPhoneLoadNameBuffer:: ds 1 ; c6d0
@@ -795,7 +806,7 @@ wPokegearMapPlayerIconLandmark:: ds 1 ; c6d8
 wPokegearRadioChannelBank:: ds 1 ; c6d9
 wPokegearRadioChannelAddr:: ds 2 ; c6da
 wPokegearRadioMusicPlaying:: ds 1 ; c6dc
-	ds wc6d0 - @
+NEXTU
 
 wSlots::
 ; Slot Machine
@@ -821,8 +832,7 @@ wSlotBuildingMatch:: ds 1
 wSlotsDataEnd::
 	ds 28
 wSlotsEnd::
-	ds wSlots - @
-
+NEXTU
 ; Card Flip
 ; c6d0
 wCardFlip::
@@ -834,8 +844,7 @@ wCardFlipFaceUpCard:: ds 1
 wDiscardPile:: ds 24
 wDiscardPileEnd::
 wCardFlipEnd::
-	ds wCardFlip - @
-
+NEXTU
 ; Dummy Game
 ; c6d0
 wDummyGame::
@@ -851,14 +860,14 @@ wDummyGameLastMatches:: ds 5 ; c703
 wDummyGameCounter:: ds 1 ; c708
 wDummyGameNumCardsMatched:: ds 1 ; c709
 wDummyGameEnd::
-	ds wDummyGame - @
+NEXTU
 ; Unown Puzzle
 wUnownPuzzle::
 wPuzzlePieces::
 	ds 6 * 6
 wUnownPuzzleEnd::
 
-	ds wc6d0 - @
+NEXTU
 
 wPokedexDataStart::
 wPokedexOrder:: ds NUM_POKEMON +- 1
@@ -908,12 +917,16 @@ wMiscEnd::
 
 wc7e8:: ds 24
 
+ENDU ; Again, just has to be as large as the largest union, this is safe though
+ENDU
+
 SECTION "Overworld Map", WRAM0 [$c800]
 
+UNION
 OverworldMap:: ; c800
 	ds 1300
 OverworldMapEnd::
-	ds OverworldMap - @
+NEXTU
 
 wBillsPCPokemonList::
 ; Pokemon, box number, list index
@@ -927,6 +940,7 @@ wLinkPartyCount:: ds 1
 wLinkPartySpecies:: ds PARTY_LENGTH
 wLinkPartySpeciesEnd:: ds 1
 
+UNION
 wTimeCapsulePlayerData::
 wTimeCapsulePartyMon1:: red_party_struct wTimeCapsulePartyMon1
 wTimeCapsulePartyMon2:: red_party_struct wTimeCapsulePartyMon2
@@ -937,7 +951,7 @@ wTimeCapsulePartyMon6:: red_party_struct wTimeCapsulePartyMon6
 wTimeCapsulePartyMonOTNames:: ds PARTY_LENGTH * NAME_LENGTH
 wTimeCapsulePartyMonNicks:: ds PARTY_LENGTH * PKMN_NAME_LENGTH
 wTimeCapsulePlayerDataEnd::
-	ds wTimeCapsulePlayerData - @
+NEXTU
 
 wLinkPlayerData::
 wLinkPlayerPartyMon1:: party_struct wLinkPlayerPartyMon1
@@ -950,10 +964,9 @@ wLinkPlayerPartyMonOTNames:: ds PARTY_LENGTH * NAME_LENGTH
 wLinkPlayerPartyMonNicks:: ds PARTY_LENGTH * PKMN_NAME_LENGTH
 wLinkPlayerDataEnd::
 	ds $35d
-
+ENDU
 wLinkDataEnd::
-	ds wLinkData - @
-
+NEXTU
 wc800::	ds 1
 wc801:: ds 1
 wc802:: ds 1
@@ -971,13 +984,15 @@ wc820:: ds 1
 wc821:: ds 15
 wc830:: ds 16
 wc840:: ds 16
+UNION ; another sub union
 wMysteryGiftTrainerData:: ds (1 + 1 + NUM_MOVES) * PARTY_LENGTH + 2
 wMysteryGiftTrainerDataEnd::
-	ds wMysteryGiftTrainerData - @
+NEXTU
 wc850:: ds 16
 wc860:: ds 16
 wc870:: ds 16
 wc880:: ds 16
+ENDU
 wc890:: ds 16
 wc8a0:: ds 16
 wc8b0:: ds 16
@@ -1114,7 +1129,10 @@ wccb8:: ds 1
 wccb9:: ds 1
 wccba:: ds 102
 
+ENDU ; very late for safety
+
 SECTION "Video", WRAM0
+UNION
 CreditsPos::
 BGMapBuffer::
 wMobileMonSpeciesPointerBuffer:: dw
@@ -1122,7 +1140,7 @@ wMobileMonStructurePointerBuffer:: dw
 wMobileMonOTNamePointerBuffer:: dw
 wMobileMonNicknamePointerBuffer:: dw
 wMobileMonMailPointerBuffer:: dw
-	ds CreditsPos - @
+NEXTU
 
 wcd20:: ds 1
 wcd21:: ds 1
@@ -1168,6 +1186,8 @@ wcd44:: ds 1
 wcd45:: ds 1
 wcd46:: ds 1
 wcd47:: ds 1
+
+ENDU ; this union could end earlier, but this is safe enough
 
 BGMapPalBuffer:: ; cd48
 	ds 1 ; 40
@@ -1257,11 +1277,13 @@ AttrMap:: ; cdd9
 ; bit 0-2: palette id
 	ds SCREEN_WIDTH * SCREEN_HEIGHT
 AttrMapEnd::
+
+UNION
 	ds 1
 wcf42:: ds 2
 wcf44:: ds 1
 wcf45::
-	ds AttrMapEnd - @
+NEXTU
 wTileAnimBuffer::
 	ds $10
 ; addresses dealing with serial comms
@@ -1272,6 +1294,8 @@ wcf57:: ds 4
 wcf5b:: ds 1
 wcf5c:: ds 1
 wcf5d:: ds 2
+
+ENDU ; later than necessary
 
 MonType:: ; cf5f
 	ds 1
@@ -1524,16 +1548,16 @@ wOptionsMenuPreset:: ds 1
 wRAM0End:: ; cfd8
 
 
-SECTION "WRAM 1", WRAMX, BANK [1]
+SECTION "WRAM 1", WRAMX [$d000], BANK [1]
 
 wd000:: ds 1
 DefaultSpawnpoint::
 wd001:: ds 1
 
 ; d002
+UNION
 wTempMail:: mailmsg wTempMail
-	ds wTempMail - @
-
+NEXTU
 wSeerAction:: ds 1
 wSeerNickname:: ds PKMN_NAME_LENGTH
 wSeerCaughtLocation:: ds 17
@@ -1544,14 +1568,14 @@ wSeerCaughtLevelString:: ds 4
 wSeerCaughtLevel:: ds 1
 wSeerCaughtData:: ds 1
 wSeerCaughtGender:: ds 1
-	ds wSeerAction - @
+NEXTU
 
 wBufferMonNick:: ds PKMN_NAME_LENGTH
 wBufferMonOT:: ds NAME_LENGTH
 wBufferMon:: party_struct wBufferMon
 	ds 8
 wMonOrItemNameBuffer::
-	ds wBufferMonNick - @
+NEXTU
 
 bugcontestwinner: macro
 \1PersonID:: ds 1
@@ -1567,7 +1591,7 @@ wBugContestWinnersEnd::
 	ds 4
 wBugContestWinnerName:: ds NAME_LENGTH
 
-	ds wBugContestResults - @
+NEXTU
 
 wd002::
 wTempDayOfWeek::
@@ -1614,9 +1638,10 @@ wd00a:: ds 1
 wMartItem4BCD::
 wd00b:: ds 1
 
+UNION ; sub union
 wRadioText:: ds 2 * SCREEN_WIDTH
 wRadioTextEnd::
-	ds wRadioText - @
+NEXTU
 
 wMobileParticipant2Nickname::
 wd00c:: ds 1
@@ -1652,6 +1677,7 @@ wd031:: ds 1
 wd032:: ds 1
 wd033:: ds 1
 wd034:: ds 2
+ENDU ; end sub union
 wd036:: ds 2
 wd038:: ds 3
 wd03b:: ds 3
@@ -1726,6 +1752,8 @@ wTempTrainerHeaderEnd::
 wd04e:: ds 24
 wTMHMMoveNameBackup:: ds MOVE_NAME_LENGTH
 
+ENDU
+
 StringBuffer1:: ; d073
 	ds 19
 
@@ -1789,9 +1817,10 @@ VramState:: ; d0ed
 
 wBattleResult:: ds 1
 wUsingItemWithSelect:: ds 1
+UNION
 CurMart:: ds 16
 CurMartEnd::
-	ds CurMart - @
+NEXTU
 CurElevator:: ds 1
 wd0f1::
 CurElevatorFloors::
@@ -1801,6 +1830,8 @@ wMailboxCount:: ds 1
 wMailboxItems:: ds MAILBOX_CAPACITY
 wMailboxEnd:: ds 1 ; d1fe
 	ds 2
+
+ENDU
 
 wd100:: ds 1
 wd101:: ds 1
@@ -1882,10 +1913,10 @@ wPlayerStepDirection:: ds 1 ; d151
 
 wBGMapAnchor:: ds 2 ; d152
 
+UNION
 UsedSprites:: ds 64 ; d154
 UsedSpritesEnd::
-	ds UsedSprites - @
-
+NEXTU
 wd154:: ; d154
 	ds 31 ; 64
 
@@ -1899,6 +1930,7 @@ wd191:: ds 1
 wd192:: ds 1
 wd193:: ds 1
 wOverworldMapAnchor:: dw ; d194
+ENDU
 wMetatileStandingY:: ds 1 ; d196
 wMetatileStandingX:: ds 1 ; d197
 wSecondMapHeaderBank:: ds 1 ; d198
@@ -2189,6 +2221,7 @@ TimeOfDay:: ; d269
 	ds 1
 
 SECTION "Enemy Party", WRAMX, BANK [1]
+UNION
 wPokedexShowPointerAddr::
 wd26b:: ds 1
 wd26c:: ds 1
@@ -2196,17 +2229,18 @@ wPokedexShowPointerBank::
 wd26d:: ds 1
 	ds 3
 wd271:: ds 5
-	ds wd26b - @
-
+NEXTU
 
 ; SECTION "Enemy Party", WRAMX, BANK [1]
 OTPlayerName:: ds NAME_LENGTH ; d26b
 OTPlayerID:: ds 2 ; d276
 	ds 8
+ENDU
 OTPartyCount::   ds 1 ; d280
 OTPartySpecies:: ds PARTY_LENGTH ; d281
 OTPartyEnd::     ds 1
 
+UNION
 wDudeBag:: ; d288
 wDudeNumItems:: ds 1
 wDudeItems:: ds 2 * 4
@@ -2220,8 +2254,7 @@ wDudeNumBalls:: ds 1 ; d2a6
 wDudeBalls:: ds 2 * 4 ; d2a7
 wDudeBallsEnd:: ds 1 ; d2af
 wDudeBagEnd::
-	ds wDudeBag - @
-
+NEXTU
 OTPartyMons::
 OTPartyMon1:: party_struct OTPartyMon1 ; d288
 OTPartyMon2:: party_struct OTPartyMon2 ; d2b8
@@ -2230,6 +2263,8 @@ OTPartyMon4:: party_struct OTPartyMon4 ; d318
 OTPartyMon5:: party_struct OTPartyMon5 ; d348
 OTPartyMon6:: party_struct OTPartyMon6 ; d378
 OTPartyMonsEnd::
+
+ENDU
 
 OTPartyMonOT:: ds NAME_LENGTH * PARTY_LENGTH ; d3a8
 OTPartyMonNicknames:: ds PKMN_NAME_LENGTH * PARTY_LENGTH ; d3ea
@@ -3020,6 +3055,7 @@ w3_d100:: ; BattleTower OpponentTrainer-Data (length = 0xe0 = $a + $1 + 3*$3b + 
 BT_OTTrainer:: battle_tower_struct BT_OT
 ; d1e0	
 	ds $20
+UNION
 ; d200
 BT_TrainerTextIndex:: ds 2
 w3_d202:: battle_tower_struct w3_d202
@@ -3030,11 +3066,14 @@ w3_d582:: battle_tower_struct w3_d582
 w3_d662:: battle_tower_struct w3_d662
 w3_d742:: battle_tower_struct w3_d742
 ; d822
-	ds -$22
-
+NEXTU
+	ds $600
 wBTChoiceOfLvlGroup::
 w3_d800:: ; ds BG_MAP_WIDTH * SCREEN_HEIGHT ($240)
 	ds $69
+
+ENDU
+
 w3_d869:: ds $17
 w3_d880:: ds 1
 w3_d881:: ds 1
@@ -3180,10 +3219,15 @@ wBattleAnimTemp7:: ds 1
 wBattleAnimTempPalette::
 wBattleAnimTemp8:: ds 1
 
+UNION
+
 wSurfWaveBGEffect:: ds $40
 wSurfWaveBGEffectEnd::
-	ds -$e
+NEXTU
+	ds $40-$e
+
 wBattleAnimEnd::
+ENDU
 
 SECTION "WRAM 5 MOBILE", WRAMX [$d800], BANK [5]
 w5_d800:: ds $200

--- a/wram.asm
+++ b/wram.asm
@@ -285,7 +285,7 @@ SpriteAnim8:: sprite_anim_struct SpriteAnim8
 wc394::
 SpriteAnim9:: sprite_anim_struct SpriteAnim9
 
-UNION ; could be moved before anim structs, add a lot of empty ds
+UNION
 wc3a4::
 SpriteAnim10:: sprite_anim_struct SpriteAnim10
 wSpriteAnimationStructsEnd::
@@ -370,16 +370,11 @@ wc608::
 wOddEgg:: party_struct OddEgg
 wOddEggName:: ds PKMN_NAME_LENGTH
 wOddEggOTName:: ds PKMN_NAME_LENGTH
-TEST3::
 NEXTU
 wBT_OTTemp:: battle_tower_struct wBT_OTTemp
-TEST2:: ;SOMETHING HERE IS FUCKY
-; FIND OUT WHY THIS IS BIGGER THAN EXPECTED
-; THEN remove the [blahblahs] I added, and fix overworld
-; TODO TODO TODO probably redo battle tbh
+
 NEXTU
 	hall_of_fame wHallOfFameTemp
-TEST1::
 NEXTU
 wMisc:: ; ds (SCREEN_WIDTH + 4) * (SCREEN_HEIGHT + 2)
 	ds 10
@@ -917,7 +912,7 @@ wMiscEnd::
 
 wc7e8:: ds 24
 
-ENDU ; Again, just has to be as large as the largest union, this is safe though
+ENDU
 ENDU
 
 SECTION "Overworld Map", WRAM0
@@ -984,7 +979,7 @@ wc820:: ds 1
 wc821:: ds 15
 wc830:: ds 16
 wc840:: ds 16
-UNION ; another sub union
+UNION ; sub union
 wMysteryGiftTrainerData:: ds (1 + 1 + NUM_MOVES) * PARTY_LENGTH + 2
 wMysteryGiftTrainerDataEnd::
 NEXTU
@@ -1129,7 +1124,7 @@ wccb8:: ds 1
 wccb9:: ds 1
 wccba:: ds 102
 
-ENDU ; very late for safety
+ENDU
 
 SECTION "Video", WRAM0
 UNION
@@ -1187,7 +1182,7 @@ wcd45:: ds 1
 wcd46:: ds 1
 wcd47:: ds 1
 
-ENDU ; this union could end earlier, but this is safe enough
+ENDU
 
 BGMapPalBuffer:: ; cd48
 	ds 1 ; 40
@@ -1295,7 +1290,7 @@ wcf5b:: ds 1
 wcf5c:: ds 1
 wcf5d:: ds 2
 
-ENDU ; later than necessary
+ENDU
 
 MonType:: ; cf5f
 	ds 1
@@ -1677,7 +1672,7 @@ wd031:: ds 1
 wd032:: ds 1
 wd033:: ds 1
 wd034:: ds 2
-ENDU ; end sub union
+ENDU
 wd036:: ds 2
 wd038:: ds 3
 wd03b:: ds 3

--- a/wram.asm
+++ b/wram.asm
@@ -2,7 +2,7 @@ INCLUDE "includes.asm"
 INCLUDE "macros/wram.asm"
 INCLUDE "vram.asm"
 
-SECTION "Stack", WRAM0 [$c000]
+SECTION "Stack", WRAM0
 wc000::
 StackBottom::
 	ds $100 - 1
@@ -11,7 +11,7 @@ StackTop::
 	ds 1
 
 
-SECTION "AudioWRAM", WRAM0 [$c100]
+SECTION "AudioWRAM", WRAM0
 wMusic::
 MusicPlaying:: ; c100
 ; nonzero if playing
@@ -134,7 +134,7 @@ wMapMusic:: ; c2c0
 wDontPlayMapMusicOnReload:: ds 1
 wMusicEnd::
 
-SECTION "WRAM", WRAM0 [$c2c2]
+SECTION "WRAM", WRAM0
 
 wLZAddress:: dw ; c2c2
 wLZBank::    db ; c2c4
@@ -216,7 +216,7 @@ TilePermissions:: ; c2fe
 
 	ds 1
 
-SECTION "wSpriteAnims", WRAM0 [$c300]
+SECTION "wSpriteAnims", WRAM0
 ; wc300 - wc313 is a 10x2 dictionary.
 ; keys: taken from third column of SpriteAnimSeqData
 ; values: VTiles
@@ -336,7 +336,7 @@ wc3fb:: ds 1
 wc3fc:: ds 4
 
 
-SECTION "Sprites", WRAM0 [$c400]
+SECTION "Sprites", WRAM0
 
 Sprites:: ; c400
 ; 4 bytes per sprite
@@ -356,7 +356,7 @@ Sprites:: ; c400
 SpritesEnd::
 
 
-SECTION "Tilemap", WRAM0 [$c4a0]
+SECTION "Tilemap", WRAM0
 
 TileMap:: ; c4a0
 ; 20x18 grid of 8x8 tiles
@@ -364,7 +364,7 @@ TileMap:: ; c4a0
 TileMapEnd::
 
 
-SECTION "Battle", WRAM0 [$c608]
+SECTION "Battle", WRAM0
 UNION
 wc608::
 wOddEgg:: party_struct OddEgg
@@ -920,7 +920,7 @@ wc7e8:: ds 24
 ENDU ; Again, just has to be as large as the largest union, this is safe though
 ENDU
 
-SECTION "Overworld Map", WRAM0 [$c800]
+SECTION "Overworld Map", WRAM0
 
 UNION
 OverworldMap:: ; c800
@@ -1548,7 +1548,7 @@ wOptionsMenuPreset:: ds 1
 wRAM0End:: ; cfd8
 
 
-SECTION "WRAM 1", WRAMX [$d000], BANK [1]
+SECTION "WRAM 1", WRAMX
 
 wd000:: ds 1
 DefaultSpawnpoint::
@@ -2220,7 +2220,7 @@ TimeOfDay:: ; d269
 
 	ds 1
 
-SECTION "Enemy Party", WRAMX, BANK [1]
+SECTION "Enemy Party", WRAMX
 UNION
 wPokedexShowPointerAddr::
 wd26b:: ds 1
@@ -2893,7 +2893,7 @@ wScreenSave:: ds 6 * 5
 wMapDataEnd::
 
 
-SECTION "Party", WRAMX, BANK [1]
+SECTION "Party", WRAMX
 
 wPokemonData::
 
@@ -3001,7 +3001,7 @@ wMagikarpRecordHoldersName:: ds NAME_LENGTH
 wPokemonDataEnd::
 wGameDataEnd::
 
-SECTION "Pic Animations", WRAMX, BANK [2]
+SECTION "Pic Animations", WRAMX
 
 TempTileMap::
 ; 20x18 grid of 8x8 tiles
@@ -3040,7 +3040,7 @@ w2_d188:: ds 1
 wPokeAnimStructEnd::
 
 
-SECTION "Battle Tower", WRAMX, BANK [3]
+SECTION "Battle Tower", WRAMX
 
 w3_d000:: ds 1 ; d000
 w3_d001:: ds 1
@@ -3095,11 +3095,11 @@ w3_dd68:: ds SCREEN_WIDTH * SCREEN_HEIGHT
 w3_dfec:: ds $10
 w3_dffc:: ds 4
 
-SECTION "Aligned Tile Map", WRAMX, BANK [4]
+SECTION "Aligned Tile Map", WRAMX
 AlignedTileMap:: ds $400
 
 
-SECTION "GBC Video", WRAMX, BANK [5]
+SECTION "GBC Video", WRAMX
 
 ; 8 4-color palettes
 UnknBGPals:: ds 8 palettes ; d000
@@ -3124,7 +3124,7 @@ LYOverridesBackup:: ; d200
 LYOverridesBackupEnd::
 
 
-SECTION "Battle Animations", WRAMX [$d300], BANK [5]
+SECTION "Battle Animations", WRAMX
 
 wBattleAnimTileDict:: ds 10
 
@@ -3229,7 +3229,7 @@ NEXTU
 wBattleAnimEnd::
 ENDU
 
-SECTION "WRAM 5 MOBILE", WRAMX [$d800], BANK [5]
+SECTION "WRAM 5 MOBILE", WRAMX
 w5_d800:: ds $200
 w5_da00:: ds $200
 w5_dc00:: ds $d
@@ -3240,7 +3240,7 @@ w5_dc26:: ds $c
 w5_dc32:: ds $c
 w5_dc3e:: ds $c
 
-SECTION "WRAM 6", WRAMX, BANK [6]
+SECTION "WRAM 6", WRAMX
 
 wDecompressScratch:: ds $400
 wBackupAttrMap:: ds $200
@@ -3249,6 +3249,6 @@ w6_d800::
 
 INCLUDE "sram.asm"
 
-SECTION "WRAM 7", WRAMX, BANK [7]
+SECTION "WRAM 7", WRAMX
 wWindowStack:: ds $1000 - 1
 wWindowStackBottom:: ds 1


### PR DESCRIPTION
Gets rid of all the nasty negative-wram syntax from old RGBDS in favor of (admittedly rather ugly) unions.

Also adds a link file to avoid things getting shifted into weird places