### PR TITLE
Fix Linux install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ cd rgbds
 sudo make install
 cd ..
 
-git clone --recursive https://github.com/dabomstew/pokecrystal-speedchoice
+git clone --recursive https://github.com/dabomstew/pokecrystal-speedchoice-legacy
 cd pokecrystal-speedchoice
 ```
 
@@ -41,7 +41,7 @@ cd rgbds-0.3.9
 sudo make install
 cd ..
 
-git clone --recursive https://github.com/dabomstew/pokecrystal-speedchoice
+git clone --recursive https://github.com/dabomstew/pokecrystal-speedchoice-legacy
 cd pokecrystal-speedchoice
 ```
 
@@ -65,7 +65,7 @@ In the **Cygwin terminal**:
 
 ```bash
 
-git clone --recursive https://github.com/dabomstew/pokecrystal-speedchoice
+git clone --recursive https://github.com/dabomstew/pokecrystal-speedchoice-legacy
 cd pokecrystal-speedchoice
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,11 +9,11 @@ If you run into trouble, ask on irc ([**freenode#pret**](https://kiwiirc.com/cli
 Python 2.7 and Python 3 are required.
 
 ```bash
-sudo apt-get install make gcc bison git python python3
+sudo apt-get install make gcc bison git python python3 libpng-dev flex
 
-wget https://github.com/rednex/rgbds/releases/download/v0.3.9/rgbds-0.3.9.tar.gz
-tar -xvf rgbds-0.3.9.tar.gz
-cd rgbds-0.3.9
+wget https://github.com/gbdev/rgbds/releases/download/v0.4.1/rgbds-0.4.1.tar.gz
+tar -xvf rgbds-0.4.1.tar.gz
+cd rgbds
 sudo make install
 cd ..
 


### PR DESCRIPTION
Added two unlisted dependencies to the `apt-get` command, and updated rgbds to 0.4.1 (latest), as speedchoice apparently needed at least 0.4.0